### PR TITLE
Fix KSMEPlayer codec type

### DIFF
--- a/Sources/KSPlayer/AVPlayer/KSPlayerLayer.swift
+++ b/Sources/KSPlayer/AVPlayer/KSPlayerLayer.swift
@@ -373,7 +373,7 @@ extension KSPlayerLayer {
         }
         let dynamicRange: DynamicRange
         let fps = track.nominalFrameRate
-        if track.codecType.string == "ehvd" {
+        if track.codecType.string == "dvhe" {
             dynamicRange = .DV
         } else if let colorPrimaries = track.colorPrimaries, /// HDR
                   colorPrimaries.contains("2020") {

--- a/Sources/KSPlayer/MEPlayer/MEPlayerItemTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/MEPlayerItemTrack.swift
@@ -39,7 +39,8 @@ struct AssetTrack: MediaPlayerTrack, CustomStringConvertible {
         colorPrimaries = stream.pointee.codecpar.pointee.color_primaries.colorPrimaries as String?
         transferFunction = stream.pointee.codecpar.pointee.color_trc.transferFunction as String?
         yCbCrMatrix = stream.pointee.codecpar.pointee.color_space.ycbcrMatrix as String?
-        codecType = stream.pointee.codecpar.pointee.codec_tag
+        // codec_tag byte order is LSB first
+        codecType = stream.pointee.codecpar.pointee.codec_tag.bigEndian
         if stream.pointee.codecpar.pointee.codec_type == AVMEDIA_TYPE_AUDIO {
             mediaType = .audio
         } else if stream.pointee.codecpar.pointee.codec_type == AVMEDIA_TYPE_VIDEO {


### PR DESCRIPTION
使用时发现avplayer和meplayer的codetype输出不一样，如杜比视界avplayer输出是`dvhe`，但meplayer输出是`ehvd`，看了下ffmpeg文档，是因为ffmpeg的codec_tag是LittleEndian字节序导致的

<img width="593" alt="Xnip2022-08-02_21-21-01" src="https://user-images.githubusercontent.com/718792/182384889-873a55a1-8e2b-469d-9c05-448ee131956e.png">

代码修改为使用BigEndian，保持和avplayer一致