### PR TITLE
MacOS fix and minor improvements

### DIFF
--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - OpenSSL (3.0.7):
     - OpenSSL/OpenSSL (= 3.0.7)
   - OpenSSL/OpenSSL (3.0.7)
-  - SwiftLint (0.39.2)
+  - SwiftLint (0.50.3)
 
 DEPENDENCIES:
   - FFmpeg (from `https://github.com/kingslay/FFmpegKit.git`, branch `main`)
@@ -68,7 +68,7 @@ SPEC CHECKSUMS:
   FFmpeg: 2feeb20f8a29ea8b9019b9fc74798694bb2c0a13
   KSPlayer: d0ee11093f3230cc235a3f555f5c4aee9052265e
   OpenSSL: 1a6bdbed836300e614db17920d46b502cd72d7fc
-  SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
+  SwiftLint: 77f7cb2b9bb81ab4a12fcc86448ba3f11afa50c6
 
 PODFILE CHECKSUM: 9116ec7b5ffddf4b72b3bc5b3c152789f18b1771
 

--- a/Sources/KSPlayer/Core/AppKitExtend.swift
+++ b/Sources/KSPlayer/Core/AppKitExtend.swift
@@ -257,33 +257,6 @@ public extension NSSlider {
         }
         set {}
     }
-
-    @IBInspectable var maximumValue: Float {
-        get {
-            Float(maxValue)
-        }
-        set {
-            maxValue = Double(newValue)
-        }
-    }
-
-    @IBInspectable var minimumValue: Float {
-        get {
-            Float(minValue)
-        }
-        set {
-            minValue = Double(newValue)
-        }
-    }
-
-    @IBInspectable var value: Float {
-        get {
-            floatValue
-        }
-        set {
-            floatValue = newValue
-        }
-    }
 }
 
 public extension NSStackView {
@@ -500,6 +473,7 @@ public class KSSlider: NSSlider {
     weak var delegate: KSSliderDelegate?
     public var trackHeigt = CGFloat(2)
     public var isPlayable = false
+    public var isUserInteractionEnabled: Bool = true
     public convenience init() {
         self.init(frame: .zero)
     }
@@ -516,10 +490,39 @@ public class KSSlider: NSSlider {
     }
 
     @objc private func progressSliderTouchEnded(_ sender: KSSlider) {
-        delegate?.slider(value: Double(sender.floatValue), event: .touchUpInside)
+        if isUserInteractionEnabled {
+            delegate?.slider(value: Double(sender.floatValue), event: .touchUpInside)
+        }
     }
 
     open func setThumbImage(_: UIImage?, for _: State) {}
+    
+    @IBInspectable var maximumValue: Float {
+        get {
+            Float(maxValue)
+        }
+        set {
+            maxValue = Double(newValue)
+        }
+    }
+
+    @IBInspectable var minimumValue: Float {
+        get {
+            Float(minValue)
+        }
+        set {
+            minValue = Double(newValue)
+        }
+    }
+
+    @IBInspectable var value: Float {
+        get {
+            floatValue
+        }
+        set {
+            floatValue = newValue
+        }
+    }
 }
 
 extension UIView {

--- a/Sources/KSPlayer/Core/KSMenu.swift
+++ b/Sources/KSPlayer/Core/KSMenu.swift
@@ -1,0 +1,220 @@
+//
+//  KSMenu.swift
+//  KSPlayer
+//
+//  Created by Alanko5 on 15/12/2022.
+//
+
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
+
+final public class KSMenuBuilder {
+    static func definitionsMenu(from resource: KSPlayerResource?,
+                                selected definition: Int,
+                                completition handler: @escaping (KSAction) -> Void) -> KSMenuX? {
+        guard #available(macOS 11.0, iOS 13.0, tvOS 14.0, *) else { return nil }
+        guard let resource, resource.definitions.count > 1 else { return nil }
+
+        var actions: [KSAction] = []
+        resource.definitions.enumerated().forEach { index, currentDefinition in
+            let definitionItem = KSAction.initialize(title: currentDefinition.definition,
+                                                     tag: index,
+                                                     completition: handler)
+            if index == definition {
+                definitionItem.state = .on
+            }
+            actions.append(definitionItem)
+        }
+
+        let menu = KSMenuX.initialize(title: NSLocalizedString("select video quality", comment: ""), items: actions)
+
+        return menu
+    }
+
+    static func playbackRateMenu(_ currentRate: Double,
+                                 speeds: [Double] = [0.75, 1.0, 1.25, 1.5, 2.0],
+                                 completition handler: @escaping (Double) -> Void) -> KSMenuX? {
+        guard #available(macOS 11.0, iOS 13.0, tvOS 14.0, *) else { return nil }
+
+        var actions: [KSAction] = []
+        speeds.enumerated().forEach { index, rate in
+            let title = "\(rate) x"
+            let rateItem = KSAction.initialize(title: title,
+                                               tag: index) { action in
+                guard speeds.count > action.tag  else { return }
+                handler(speeds[action.tag])
+            }
+            if currentRate == rate {
+                rateItem.state = .on
+            }
+            actions.append(rateItem)
+        }
+        let menu = KSMenuX.initialize(title: NSLocalizedString("speed", comment: ""), items: actions)
+        return menu
+    }
+
+    static func audioVideoChangeMenu(_ currentTrack: MediaPlayerTrack?,
+                                     availableTracks: [MediaPlayerTrack],
+                                     completition handler: @escaping (KSAction) -> Void) -> KSMenuX? {
+        guard availableTracks.count > 1,
+                let currentTrack,
+                #available(macOS 11.0, iOS 13.0, tvOS 14.0, *)
+        else { return nil }
+        let title = NSLocalizedString(currentTrack.mediaType == .audio ? "switch audio" : "switch video", comment: "")
+
+        var actions: [KSAction] = []
+        availableTracks.enumerated().forEach { index, track in
+            var title = track.name
+            if track.mediaType == .video {
+                title += " \(track.naturalSize.width)x\(track.naturalSize.height)"
+            }
+
+            let tracksItem = KSAction.initialize(title: title,
+                                                 tag: index,
+                                                 completition: handler)
+
+            if track.isEnabled {
+                tracksItem.state = .on
+            }
+            actions.append(tracksItem)
+        }
+        let menu = KSMenuX.initialize(title: title, items: actions)
+        return menu
+    }
+
+    static func srtChangeMenu(_ currentSub: SubtitleInfo?,
+                              availableSubtitles: [SubtitleInfo],
+                              completition handler: @escaping (SubtitleInfo?) -> Void) -> KSMenuX? {
+        guard availableSubtitles.count > 0, #available(macOS 11.0, iOS 13.0, tvOS 14.0, *) else { return nil }
+        var actions: [KSAction] = []
+
+        let subtitleItem = KSAction.initialize(title: "Disabled",
+                                               tag: -1) { _ in
+            handler(nil)
+        }
+        if currentSub == nil {
+            subtitleItem.state = .on
+        }
+        actions.append(subtitleItem)
+
+        availableSubtitles.enumerated().forEach { index, srt in
+            let subtitleItem = KSAction.initialize(title: srt.name,
+                                                   tag: index) { _ in
+                let selectedSrt = availableSubtitles[index]
+                handler(selectedSrt)
+            }
+            if srt.subtitleID == currentSub?.subtitleID {
+                subtitleItem.state = .on
+            }
+            actions.append(subtitleItem)
+        }
+
+        let menu = KSMenuX.initialize(title: NSLocalizedString("subtitle", comment: ""), items: actions)
+        return menu
+    }
+}
+
+#if canImport(UIKit)
+final public class KSAction: UIAction {
+    var tag: Int = 0
+
+    @available(macOS 11.0, iOS 13.0, tvOS 14.0, *)
+    static func initialize(title string: String,
+                           keyEquivalent charCode: String = "",
+                           state: KSMenuX.State = .off,
+                           tag: Int = 0,
+                           completition handler: @escaping (KSAction) -> Void) -> KSAction {
+
+        let action = KSAction(title: string,
+                              image: nil,
+                              identifier: nil,
+                              discoverabilityTitle: nil,
+                              attributes: [],
+                              state: state.value) { action in
+            guard let action = action as? KSAction else { return }
+            handler(action)
+        }
+        action.tag = tag
+
+        return action
+    }
+}
+
+final public class KSMenuX: UIMenu {
+    @available(iOS 13.0, tvOS 14.0, *)
+    static func initialize(title: String, items: [KSAction]) -> KSMenuX {
+        return KSMenuX.init(title: title, children: items)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+#else
+final public class KSAction: NSMenuItem {
+    var completition: ((KSAction) -> Void)?
+
+    static func initialize(title string: String,
+                           keyEquivalent charCode: String = "",
+                           state: KSMenuX.State = .off,
+                           tag: Int = 0,
+                           completition: @escaping (KSAction) -> Void) -> KSAction {
+        let menuItem = KSAction(title: string, action: #selector(menuPressed), keyEquivalent: charCode)
+        menuItem.completition = completition
+        menuItem.state = state.value
+        menuItem.target = menuItem
+        menuItem.tag = tag
+        return menuItem
+    }
+
+    @objc internal func menuPressed() {
+        completition?(self)
+    }
+}
+
+final public class KSMenuX: NSMenu {
+    static func initialize(title: String, items: [KSAction]) -> KSMenuX {
+        let menu = KSMenuX(title: title)
+        for item in items {
+            menu.addItem(item)
+        }
+        return menu
+    }
+}
+#endif
+
+public extension KSMenuX {
+    // swiftlint:disable identifier_name
+    enum State: Int, @unchecked Sendable {
+        case off = 0
+        case on = 1
+        case mixed = 2
+
+    #if canImport(UIKit)
+        var value: UIMenuElement.State {
+            switch self {
+            case .off:
+                return .off
+            case .on:
+                return .on
+            case .mixed:
+                return .mixed
+            }
+        }
+    #else
+        var value: NSControl.StateValue {
+            switch self {
+            case .off:
+                return .off
+            case .on:
+                return .on
+            case .mixed:
+                return .mixed
+            }
+        }
+    #endif
+    }
+}

--- a/Sources/KSPlayer/Core/PlayerToolBar.swift
+++ b/Sources/KSPlayer/Core/PlayerToolBar.swift
@@ -46,8 +46,26 @@ public class PlayerToolBar: UIStackView {
                 let text = currentTime.toString(for: timeType)
                 currentTimeLabel.text = text
                 timeLabel.text = "\(text) / \(totalTime.toString(for: timeType))"
-                timeSlider.value = Float(currentTime)
+                if isLiveStream {
+                    timeSlider.value = Float(todayInterval)
+                } else {
+                    timeSlider.value = Float(currentTime)
+                }
             }
+        }
+    }
+
+    internal lazy var startDateTimeInteral: TimeInterval = {
+        let date = Date()
+        let calendar =  Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        let startDate = calendar.date(from: components)
+        return startDate?.timeIntervalSince1970 ?? 0
+    }()
+
+    internal var todayInterval: TimeInterval {
+        get {
+            return Date().timeIntervalSince1970 - startDateTimeInteral
         }
     }
 
@@ -63,6 +81,21 @@ public class PlayerToolBar: UIStackView {
                 timeLabel.text = "\(currentTime.toString(for: timeType)) / \(text)"
                 timeSlider.maximumValue = Float(totalTime)
             }
+            if isLiveStream {
+                timeSlider.maximumValue = Float(60 * 60 * 24)
+            }
+        }
+    }
+
+    public var isLiveStream: Bool {
+        get {
+            totalTime == 0
+        }
+    }
+
+    public var isSeekable: Bool = true {
+        didSet {
+            timeSlider.isUserInteractionEnabled = isSeekable
         }
     }
 


### PR DESCRIPTION
Fix #326 - m1 slider
in macOS it was not possible to set subtitles, audio, video, speed, etc.
I created a new class to display these settings (iOS 14 <, macOS).
Unfortunately for tvOS, I haven't found a way to display this menu yet.
For the live broadcast, I disabled the possibility of scrolling.
During live broadcasting, the slider is set according to the current time.

@kingslay, look at it.