### PR TITLE
fix: 修复刚开始播放视频时会卡一下

### DIFF
--- a/Sources/KSPlayer/MEPlayer/MEPlayerItem.swift
+++ b/Sources/KSPlayer/MEPlayer/MEPlayerItem.swift
@@ -224,7 +224,7 @@ extension MEPlayerItem {
         if formatCtx.pointee.start_time != Int64.min {
             startTime = CMTime(value: formatCtx.pointee.start_time, timescale: AV_TIME_BASE)
         }
-        currentPlaybackTime = startTime.seconds
+        // currentPlaybackTime = startTime.seconds
         duration = TimeInterval(max(formatCtx.pointee.duration, 0) / Int64(AV_TIME_BASE))
         createCodec(formatCtx: formatCtx)
         if let outputURL = options.outputURL {


### PR DESCRIPTION
使用的是tvOS Demo
测试链接是m3u8链接：https://www.whalenas.com/bestv/index.php?id=cctv1hd8m/8000000

未修复前打开播放时会卡一下再播放
修复后就直接播放了
不过暂时不清楚这样注释后，会不会带来新的问题