### PR TITLE
添加字幕删除功能

### DIFF
--- a/Sources/KSPlayer/Subtitle/KSSubtitle.swift
+++ b/Sources/KSPlayer/Subtitle/KSSubtitle.swift
@@ -354,4 +354,7 @@ open class SubtitleModel: ObservableObject {
             }
         }
     }
+    public func removeAllSubtitleInfos() {
+        subtitleInfos.removeAll()
+    }
 }


### PR DESCRIPTION
其实我没有理解到现在设置url的含义是为了什么...
这个地址是播放地址吗?
现在的问题是,如果我在subtitleModel里再传一次url,视频打开会慢好多...

我理解的这个地方应该是传一个KSPlayerLayer,然后通过player.tracks(mediaType: .subtitle) 把所有内嵌字幕预加载进去..
然后再是其他 多功能方式...

由于没理解到,现在先添加remove方法.

再说一下我的场景...
有一个在原画画质下,视频包含字幕..
在切换不同分辨下, 分辨率的字幕不是内嵌的,是另外的地址..
所以我需要在切换分辨率后,移除内嵌字幕,并且添加url字幕.