### PR TITLE
[FEATURE]: added functionality to select the default video track from MediaPlayerTrack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "ffmpegkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kingslay/FFmpegKit.git",
+      "state" : {
+        "revision" : "ce7d13b161ad527417cfda9f00eaad2f8f7f9330",
+        "version" : "6.1.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/KSPlayer/AVPlayer/KSOptions.swift
+++ b/Sources/KSPlayer/AVPlayer/KSOptions.swift
@@ -219,6 +219,9 @@ open class KSOptions {
         nil
     }
 
+    open func wantedVideo(tracks _: [MediaPlayerTrack]) -> Int?{
+        nil
+    }
     /// wanted audio stream index, or nil for automatic selection
     /// - Parameter :  audio bitRate and language
     /// - Returns: The index of the infos

--- a/Sources/KSPlayer/AVPlayer/KSOptions.swift
+++ b/Sources/KSPlayer/AVPlayer/KSOptions.swift
@@ -215,10 +215,6 @@ open class KSOptions {
     ///  wanted video stream index, or nil for automatic selection
     /// - Parameter : video bitRate
     /// - Returns: The index of the bitRates
-    open func wantedVideo(bitRates _: [Int64]) -> Int? {
-        nil
-    }
-
     open func wantedVideo(tracks _: [MediaPlayerTrack]) -> Int?{
         nil
     }

--- a/Sources/KSPlayer/MEPlayer/MEPlayerItem.swift
+++ b/Sources/KSPlayer/MEPlayer/MEPlayerItem.swift
@@ -353,7 +353,7 @@ extension MEPlayerItem {
                 $0 > 0
             }
             let wantedStreamNb: Int32
-            if !videos.isEmpty, let index = options.wantedVideo(bitRates: bitRates) {
+            if !videos.isEmpty, let index = options.wantedVideo(tracks: videos) {
                 wantedStreamNb = videos[index].trackID
             } else {
                 wantedStreamNb = -1


### PR DESCRIPTION
In some cases I want to set default quality to 360, 480 or 1080. But I don't know their bitrates. 

By passing MediaPlayerTrack as a parameter fixes this issue

```
open class SubKSOptions: KSOptions{
    open override func wantedVideo(tracks: [MediaPlayerTrack]) -> Int? {
        guard let quality_360 = tracks.first(where: {$0.formatDescription?.dimensions.height == 360}) else{
            return nil
        }
        
        guard let index = tracks.firstIndex(where: {$0.bitRate == quality_360.bitRate})else{
            return nil
        }
        return index
    }
}

```