### PR TITLE
fix: language as subtitle name if name is nil, instead of codec

### DIFF
--- a/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
@@ -104,7 +104,7 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
         if let value = metadata["title"] {
             name = value
         } else {
-            name = codecName
+            name = languageCode ?? codecName
         }
         // AV_DISPOSITION_DEFAULT
         if mediaType == .subtitle {


### PR DESCRIPTION
https://github.com/kingslay/KSPlayer/issues/710