### PR TITLE
Update UI on visionOS

### DIFF
--- a/Sources/KSPlayer/AVPlayer/KSVideoPlayer.swift
+++ b/Sources/KSPlayer/AVPlayer/KSVideoPlayer.swift
@@ -93,6 +93,13 @@ extension KSVideoPlayer: UIViewRepresentable {
                 playerLayer?.player.isMuted = isMuted
             }
         }
+        
+        @Published
+        public var playbackVolume: Float = 1.0 {
+            didSet {
+                playerLayer?.player.playbackVolume = playbackVolume
+            }
+        }
 
         @Published
         public var isScaleAspectFill = false {

--- a/Sources/KSPlayer/Subtitle/KSSubtitle.swift
+++ b/Sources/KSPlayer/Subtitle/KSSubtitle.swift
@@ -238,7 +238,7 @@ open class SubtitleModel: ObservableObject {
         public var rawValue: CGFloat {
             switch self {
             case .smaller:
-                #if os(tvOS)
+                #if os(tvOS) || os(xrOS)
                 return 48
                 #elseif os(macOS)
                 return 20
@@ -246,7 +246,7 @@ open class SubtitleModel: ObservableObject {
                 return 12
                 #endif
             case .standard:
-                #if os(tvOS)
+                #if os(tvOS) || os(xrOS)
                 return 58
                 #elseif os(macOS)
                 return 26
@@ -254,7 +254,7 @@ open class SubtitleModel: ObservableObject {
                 return 16
                 #endif
             case .large:
-                #if os(tvOS)
+                #if os(tvOS) || os(xrOS)
                 return 68
                 #elseif os(macOS)
                 return 32

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -391,7 +391,9 @@ struct VideoControllerView: View {
                     .opacity(config.state == .buffering ? 1 : 0)
                 Spacer()
                 playbackRateButton
+                #if !os(xrOS)
                 pipButton
+                #endif
                 infoButton
                 // iOS 模拟器加keyboardShortcut会导致KSVideoPlayer.Coordinator无法释放。真机不会有这个问题
                 #if !os(tvOS)

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -384,6 +384,10 @@ struct VideoControllerView: View {
                 Spacer()
                 if let audioTracks = config.playerLayer?.player.tracks(mediaType: .audio), !audioTracks.isEmpty {
                     audioButton(audioTracks: audioTracks)
+                    #if os(xrOS)
+                        .aspectRatio(1, contentMode: .fit)
+                        .glassBackgroundEffect()
+                    #endif
                 }
                 muteButton
                 #if !os(xrOS)
@@ -455,6 +459,10 @@ struct VideoControllerView: View {
             }
         } label: {
             Image(systemName: "waveform.circle.fill")
+            #if os(xrOS)
+                .padding()
+                .clipShape(Circle())
+            #endif
         }
     }
 

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -53,15 +53,17 @@ public struct KSVideoPlayerView: View {
 
     public var body: some View {
         ZStack {
-            playView
-            VideoSubtitleView(model: playerCoordinator.subtitleModel)
-            controllerView
-            #if os(tvOS)
-            if isDropdownShow {
-                VideoSettingView(config: playerCoordinator, subtitleModel: playerCoordinator.subtitleModel, subtitleTitle: title)
-                    .focused($focusableField, equals: .info)
+            GeometryReader { proxy in
+                playView
+                VideoSubtitleView(model: playerCoordinator.subtitleModel)
+                controllerView(playerWidth: proxy.size.width)
+                #if os(tvOS)
+                if isDropdownShow {
+                    VideoSettingView(config: playerCoordinator, subtitleModel: playerCoordinator.subtitleModel, subtitleTitle: title)
+                        .focused($focusableField, equals: .info)
+                }
+                #endif
             }
-            #endif
         }
         .preferredColorScheme(.dark)
         .tint(.white)
@@ -205,9 +207,10 @@ public struct KSVideoPlayerView: View {
         #endif
     }
 
-    private var controllerView: some View {
+    private func controllerView(playerWidth: Double) -> some View {
         VStack {
             VideoControllerView(config: playerCoordinator, subtitleModel: playerCoordinator.subtitleModel, title: $title)
+            #if !os(xrOS)
             // 设置opacity为0，还是会去更新View。所以只能这样了
             if playerCoordinator.isMaskShow {
                 VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
@@ -218,7 +221,16 @@ public struct KSVideoPlayerView: View {
                         focusableField = .play
                     }
             }
+            #endif
         }
+        #if os(xrOS)
+        .ornament(visibility: playerCoordinator.isMaskShow ? .visible : .hidden, attachmentAnchor: .scene(.bottom)) {
+            VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
+                .frame(width: playerWidth / 2)
+                .padding([.all], 24)
+                .glassBackgroundEffect()
+        }
+        #endif
         .focused($focusableField, equals: .controller)
         .opacity(playerCoordinator.isMaskShow ? 1 : 0)
         .padding()

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -218,7 +218,7 @@ public struct KSVideoPlayerView: View {
 
     private func controllerView(playerWidth: Double) -> some View {
         VStack {
-            VideoControllerView(config: playerCoordinator, subtitleModel: playerCoordinator.subtitleModel, title: $title)
+            VideoControllerView(config: playerCoordinator, subtitleModel: playerCoordinator.subtitleModel, title: $title, volumeSliderSize: playerWidth / 4)
             #if !os(xrOS)
             // 设置opacity为0，还是会去更新View。所以只能这样了
             if playerCoordinator.isMaskShow {
@@ -328,6 +328,7 @@ struct VideoControllerView: View {
     fileprivate var subtitleModel: SubtitleModel
     @Binding
     fileprivate var title: String
+    fileprivate var volumeSliderSize: Double?
     @State
     private var showVideoSetting = false
     @Environment(\.dismiss)
@@ -379,8 +380,8 @@ struct VideoControllerView: View {
                     AirPlayView().fixedSize()
                 }
                 #endif
-                Spacer()
                 #endif
+                Spacer()
                 if let audioTracks = config.playerLayer?.player.tracks(mediaType: .audio), !audioTracks.isEmpty {
                     audioButton(audioTracks: audioTracks)
                 }
@@ -420,12 +421,21 @@ struct VideoControllerView: View {
     }
 
     private var muteButton: some View {
-        Button {
-            config.isMuted.toggle()
-        } label: {
-            Image(systemName: config.isMuted ? "speaker.slash.circle.fill" : "speaker.wave.2.circle.fill")
+        #if os(xrOS)
+        HStack {
+            Slider(value: $config.playbackVolume, in: 0...1)
+                .onChange(of: config.playbackVolume, { _, newValue in
+                config.isMuted = newValue == 0
+            })
+            .frame(width: volumeSliderSize ?? 100)
+            .padding(.leading, 16)
+            KSVideoPlayerViewBuilder.muteButton(config: config)
         }
-        .shadow(color: .black, radius: 1)
+        .padding(16)
+        .glassBackgroundEffect()
+        #else
+        KSVideoPlayerViewBuilder.muteButton(config: config)
+        #endif
     }
 
     private var contentModeButton: some View {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -226,11 +226,11 @@ public struct KSVideoPlayerView: View {
         #if os(xrOS)
         .ornament(visibility: playerCoordinator.isMaskShow ? .visible : .hidden, attachmentAnchor: .scene(.bottom)) {
             HStack {
-                KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator)
+                KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator, spacing: 16)
                 VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
-                    .frame(width: playerWidth / 2)
                 KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
             }
+            .frame(width: playerWidth / 2)
             .buttonStyle(.plain)
             .padding([.all], 24)
             .glassBackgroundEffect()

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -229,6 +229,7 @@ public struct KSVideoPlayerView: View {
                 KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator)
                 VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
                     .frame(width: playerWidth / 2)
+                KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
             }
             .buttonStyle(.plain)
             .padding([.all], 24)
@@ -356,7 +357,9 @@ struct VideoControllerView: View {
                     audioButton(audioTracks: audioTracks)
                 }
                 muteButton
+                #if !os(xrOS)
                 contentModeButton
+                #endif
                 subtitleButton
             }
             Spacer()
@@ -401,11 +404,7 @@ struct VideoControllerView: View {
     }
 
     private var contentModeButton: some View {
-        Button {
-            config.isScaleAspectFill.toggle()
-        } label: {
-            Image(systemName: config.isScaleAspectFill ? "rectangle.arrowtriangle.2.inward" : "rectangle.arrowtriangle.2.outward")
-        }
+        KSVideoPlayerViewBuilder.contentModeButton(config: config)
     }
 
     private func audioButton(audioTracks: [MediaPlayerTrack]) -> some View {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -55,7 +55,16 @@ public struct KSVideoPlayerView: View {
         ZStack {
             GeometryReader { proxy in
                 playView
+                #if os(xrOS)
+                HStack {
+                    Spacer()
+                    VideoSubtitleView(model: playerCoordinator.subtitleModel)
+                    Spacer()
+                }
+                .padding()
+                #else
                 VideoSubtitleView(model: playerCoordinator.subtitleModel)
+                #endif
                 controllerView(playerWidth: proxy.size.width)
                 #if os(tvOS)
                 if isDropdownShow {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -240,18 +240,23 @@ public struct KSVideoPlayerView: View {
         }
         .frame(width: playerWidth / 1.5)
         .buttonStyle(.plain)
-        .padding([.all], 24)
-        .font(.largeTitle)
+        .padding(.vertical, 24)
+        .padding(.horizontal, 36)
         .glassBackgroundEffect()
     }
     
     private func ornamentControlsView(playerWidth: Double) -> some View {
         HStack {
             KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator, spacing: 16)
-            VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
-            KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
-            KSVideoPlayerViewBuilder.subtitleButton(config: playerCoordinator)
-            KSVideoPlayerViewBuilder.playbackRateButton(playbackRate: $playerCoordinator.playbackRate)
+            Spacer()
+            VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel, timeFont: .title3.monospacedDigit())
+            Spacer()
+            Group {
+                KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
+                KSVideoPlayerViewBuilder.subtitleButton(config: playerCoordinator)
+                KSVideoPlayerViewBuilder.playbackRateButton(playbackRate: $playerCoordinator.playbackRate)
+            }
+            .font(.largeTitle)
         }
     }
 
@@ -496,12 +501,13 @@ struct VideoTimeShowView: View {
     fileprivate var config: KSVideoPlayer.Coordinator
     @ObservedObject
     fileprivate var model: ControllerTimeModel
+    fileprivate var timeFont: Font?
     public var body: some View {
         if config.timemodel.totalTime == 0 {
             Text("Live Streaming")
         } else {
             HStack {
-                Text(model.currentTime.toString(for: .minOrHour)).font(.caption2.monospacedDigit())
+                Text(model.currentTime.toString(for: .minOrHour)).font(timeFont ?? .caption2.monospacedDigit())
                 Slider(value: Binding {
                     Double(model.currentTime)
                 } set: { newValue, _ in
@@ -514,7 +520,7 @@ struct VideoTimeShowView: View {
                     }
                 }
                 .frame(maxHeight: 20)
-                Text((model.totalTime).toString(for: .minOrHour)).font(.caption2.monospacedDigit())
+                Text((model.totalTime).toString(for: .minOrHour)).font(timeFont ?? .caption2.monospacedDigit())
             }
             .font(.system(.title2))
         }

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -225,23 +225,34 @@ public struct KSVideoPlayerView: View {
         }
         #if os(xrOS)
         .ornament(visibility: playerCoordinator.isMaskShow ? .visible : .hidden, attachmentAnchor: .scene(.bottom)) {
-            HStack {
-                KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator, spacing: 16)
-                VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
-                KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
-                KSVideoPlayerViewBuilder.subtitleButton(config: playerCoordinator)
-                KSVideoPlayerViewBuilder.playbackRateButton(playbackRate: $playerCoordinator.playbackRate)
-            }
-            .frame(width: playerWidth / 1.5)
-            .buttonStyle(.plain)
-            .padding([.all], 24)
-            .font(.largeTitle)
-            .glassBackgroundEffect()
+            ornamentView(playerWidth: playerWidth)
         }
         #endif
         .focused($focusableField, equals: .controller)
         .opacity(playerCoordinator.isMaskShow ? 1 : 0)
         .padding()
+    }
+    
+    private func ornamentView(playerWidth: Double) -> some View {
+        VStack {
+            KSVideoPlayerViewBuilder.titleView(title: title, config: playerCoordinator)
+            ornamentControlsView(playerWidth: playerWidth)
+        }
+        .frame(width: playerWidth / 1.5)
+        .buttonStyle(.plain)
+        .padding([.all], 24)
+        .font(.largeTitle)
+        .glassBackgroundEffect()
+    }
+    
+    private func ornamentControlsView(playerWidth: Double) -> some View {
+        HStack {
+            KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator, spacing: 16)
+            VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
+            KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
+            KSVideoPlayerViewBuilder.subtitleButton(config: playerCoordinator)
+            KSVideoPlayerViewBuilder.playbackRateButton(playbackRate: $playerCoordinator.playbackRate)
+        }
     }
 
     fileprivate enum FocusableField {
@@ -371,12 +382,9 @@ struct VideoControllerView: View {
             Spacer()
             #endif
             HStack {
-                Text(title)
-                    .font(.title3)
-                ProgressView()
-                    .opacity(config.state == .buffering ? 1 : 0)
-                Spacer()
                 #if !os(xrOS)
+                KSVideoPlayerViewBuilder.titleView(title: title, config: config)
+                Spacer()
                 playbackRateButton
                 pipButton
                 #endif

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -230,6 +230,7 @@ public struct KSVideoPlayerView: View {
                 VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
                 KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
                 KSVideoPlayerViewBuilder.subtitleButton(config: playerCoordinator)
+                KSVideoPlayerViewBuilder.playbackRateButton(playbackRate: $playerCoordinator.playbackRate)
             }
             .frame(width: playerWidth / 1.5)
             .buttonStyle(.plain)
@@ -375,8 +376,8 @@ struct VideoControllerView: View {
                 ProgressView()
                     .opacity(config.state == .buffering ? 1 : 0)
                 Spacer()
-                playbackRateButton
                 #if !os(xrOS)
+                playbackRateButton
                 pipButton
                 #endif
                 infoButton
@@ -430,15 +431,7 @@ struct VideoControllerView: View {
     }
 
     private var playbackRateButton: some View {
-        MenuView(selection: $config.playbackRate) {
-            ForEach([0.5, 1.0, 1.25, 1.5, 2.0] as [Float]) { value in
-                // 需要有一个变量text。不然会自动帮忙加很多0
-                let text = "\(value) x"
-                Text(text).tag(value)
-            }
-        } label: {
-            Image(systemName: "gauge.with.dots.needle.67percent")
-        }
+        KSVideoPlayerViewBuilder.playbackRateButton(playbackRate: $config.playbackRate)
     }
 
     private var pipButton: some View {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -229,10 +229,12 @@ public struct KSVideoPlayerView: View {
                 KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator, spacing: 16)
                 VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
                 KSVideoPlayerViewBuilder.contentModeButton(config: playerCoordinator)
+                KSVideoPlayerViewBuilder.subtitleButton(config: playerCoordinator)
             }
-            .frame(width: playerWidth / 2)
+            .frame(width: playerWidth / 1.5)
             .buttonStyle(.plain)
             .padding([.all], 24)
+            .font(.largeTitle)
             .glassBackgroundEffect()
         }
         #endif
@@ -359,8 +361,8 @@ struct VideoControllerView: View {
                 muteButton
                 #if !os(xrOS)
                 contentModeButton
-                #endif
                 subtitleButton
+                #endif
             }
             Spacer()
             #if !os(xrOS)
@@ -424,23 +426,7 @@ struct VideoControllerView: View {
     }
 
     private var subtitleButton: some View {
-        MenuView(selection: Binding {
-            subtitleModel.selectedSubtitleInfo?.subtitleID
-        } set: { value in
-            let info = subtitleModel.subtitleInfos.first { $0.subtitleID == value }
-            subtitleModel.selectedSubtitleInfo = info
-            if let info = info as? MediaPlayerTrack {
-                // 因为图片字幕想要实时的显示，那就需要seek。所以需要走select track
-                config.playerLayer?.player.select(track: info)
-            }
-        }) {
-            Text("Off").tag(nil as String?)
-            ForEach(subtitleModel.subtitleInfos, id: \.subtitleID) { track in
-                Text(track.name).tag(track.subtitleID as String?)
-            }
-        } label: {
-            Image(systemName: "text.bubble.fill")
-        }
+        KSVideoPlayerViewBuilder.subtitleButton(config: config)
     }
 
     private var playbackRateButton: some View {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -225,10 +225,14 @@ public struct KSVideoPlayerView: View {
         }
         #if os(xrOS)
         .ornament(visibility: playerCoordinator.isMaskShow ? .visible : .hidden, attachmentAnchor: .scene(.bottom)) {
-            VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
-                .frame(width: playerWidth / 2)
-                .padding([.all], 24)
-                .glassBackgroundEffect()
+            HStack {
+                KSVideoPlayerViewBuilder.playbackControlView(config: playerCoordinator)
+                VideoTimeShowView(config: playerCoordinator, model: playerCoordinator.timemodel)
+                    .frame(width: playerWidth / 2)
+            }
+            .buttonStyle(.plain)
+            .padding([.all], 24)
+            .glassBackgroundEffect()
         }
         #endif
         .focused($focusableField, equals: .controller)
@@ -335,17 +339,19 @@ struct VideoControllerView: View {
             }
             #else
             HStack {
+                #if !os(xrOS)
                 Button {
                     dismiss()
                 } label: {
                     Image(systemName: "x.circle.fill")
                 }
-                #if !os(tvOS) && !os(xrOS)
+                #if !os(tvOS)
                 if config.playerLayer?.player.allowsExternalPlayback == true {
                     AirPlayView().fixedSize()
                 }
                 #endif
                 Spacer()
+                #endif
                 if let audioTracks = config.playerLayer?.player.tracks(mediaType: .audio), !audioTracks.isEmpty {
                     audioButton(audioTracks: audioTracks)
                 }
@@ -354,48 +360,10 @@ struct VideoControllerView: View {
                 subtitleButton
             }
             Spacer()
-            HStack {
-                Spacer()
-                if config.playerLayer?.player.seekable ?? false {
-                    Button {
-                        config.skip(interval: -15)
-                    } label: {
-                        Image(systemName: "gobackward.15")
-                            .font(.largeTitle)
-                    }
-                    #if !os(tvOS)
-                    .keyboardShortcut(.leftArrow, modifiers: .none)
-                    #endif
-                }
-                Spacer()
-                Button {
-                    if config.state.isPlaying {
-                        config.playerLayer?.pause()
-                    } else {
-                        config.playerLayer?.play()
-                    }
-                } label: {
-                    Image(systemName: config.state == .error ? "play.slash.fill" : (config.state.isPlaying ? "pause.circle.fill" : "play.circle.fill"))
-                        .font(.largeTitle)
-                }
-                #if !os(tvOS)
-                .keyboardShortcut(.space, modifiers: .none)
-                #endif
-                Spacer()
-                if config.playerLayer?.player.seekable ?? false {
-                    Button {
-                        config.skip(interval: 15)
-                    } label: {
-                        Image(systemName: "goforward.15")
-                            .font(.largeTitle)
-                    }
-                    #if !os(tvOS)
-                    .keyboardShortcut(.rightArrow, modifiers: .none)
-                    #endif
-                }
-                Spacer()
-            }
+            #if !os(xrOS)
+            KSVideoPlayerViewBuilder.playbackControlView(config: config)
             Spacer()
+            #endif
             HStack {
                 Text(title)
                     .font(.title3)

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -58,6 +58,19 @@ enum KSVideoPlayerViewBuilder {
             Image(systemName: "text.bubble.fill")
         }
     }
+    
+    @MainActor
+    static func playbackRateButton(playbackRate: Binding<Float>) -> some View {
+        MenuView(selection: playbackRate) {
+            ForEach([0.5, 1.0, 1.25, 1.5, 2.0] as [Float]) { value in
+                // 需要有一个变量text。不然会自动帮忙加很多0
+                let text = "\(value) x"
+                Text(text).tag(value)
+            }
+        } label: {
+            Image(systemName: "gauge.with.dots.needle.67percent")
+        }
+    }
 }
 
 private extension KSVideoPlayerViewBuilder {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -71,6 +71,16 @@ enum KSVideoPlayerViewBuilder {
             Image(systemName: "gauge.with.dots.needle.67percent")
         }
     }
+    
+    @MainActor
+    static func titleView(title: String, config: KSVideoPlayer.Coordinator) -> some View {
+        HStack {
+            Text(title)
+                .font(.title3)
+            ProgressView()
+                .opacity(config.state == .buffering ? 1 : 0)
+        }
+    }
 }
 
 private extension KSVideoPlayerViewBuilder {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -10,47 +10,22 @@ import SwiftUI
 enum KSVideoPlayerViewBuilder {
     
     @MainActor
-    static func playbackControlView(config: KSVideoPlayer.Coordinator) -> some View {
-        HStack {
+    static func playbackControlView(config: KSVideoPlayer.Coordinator, spacing: CGFloat? = nil) -> some View {
+        HStack(spacing: spacing) {
+            // Playback controls don't need spacers for visionOS, since the controls are laid out in a HStack.
+            #if os(xrOS)
+            backwardButton(config: config)
+            playButton(config: config)
+            forwardButton(config: config)
+            #else
             Spacer()
-            if config.playerLayer?.player.seekable ?? false {
-                Button {
-                    config.skip(interval: -15)
-                } label: {
-                    Image(systemName: "gobackward.15")
-                        .font(.largeTitle)
-                }
-                #if !os(tvOS)
-                .keyboardShortcut(.leftArrow, modifiers: .none)
-                #endif
-            }
+            backwardButton(config: config)
             Spacer()
-            Button {
-                if config.state.isPlaying {
-                    config.playerLayer?.pause()
-                } else {
-                    config.playerLayer?.play()
-                }
-            } label: {
-                Image(systemName: config.state == .error ? "play.slash.fill" : (config.state.isPlaying ? pauseSystemName : playSystemName))
-                    .font(.largeTitle)
-            }
-            #if !os(tvOS)
-            .keyboardShortcut(.space, modifiers: .none)
+            playButton(config: config)
+            Spacer()
+            forwardButton(config: config)
+            Spacer()
             #endif
-            Spacer()
-            if config.playerLayer?.player.seekable ?? false {
-                Button {
-                    config.skip(interval: 15)
-                } label: {
-                    Image(systemName: "goforward.15")
-                        .font(.largeTitle)
-                }
-                #if !os(tvOS)
-                .keyboardShortcut(.rightArrow, modifiers: .none)
-                #endif
-            }
-            Spacer()
         }
     }
     
@@ -79,6 +54,55 @@ private extension KSVideoPlayerViewBuilder {
         "pause"
         #else
         "pause.circle.fill"
+        #endif
+    }
+    
+    @MainActor
+    @ViewBuilder
+    static func backwardButton(config: KSVideoPlayer.Coordinator) -> some View {
+        if config.playerLayer?.player.seekable ?? false {
+            Button {
+                config.skip(interval: -15)
+            } label: {
+                Image(systemName: "gobackward.15")
+                    .font(.largeTitle)
+            }
+            #if !os(tvOS)
+            .keyboardShortcut(.leftArrow, modifiers: .none)
+            #endif
+        }
+    }
+    
+    @MainActor
+    @ViewBuilder
+    static func forwardButton(config: KSVideoPlayer.Coordinator) -> some View {
+        if config.playerLayer?.player.seekable ?? false {
+            Button {
+                config.skip(interval: 15)
+            } label: {
+                Image(systemName: "goforward.15")
+                    .font(.largeTitle)
+            }
+            #if !os(tvOS)
+            .keyboardShortcut(.rightArrow, modifiers: .none)
+            #endif
+        }
+    }
+    
+    @MainActor
+    static func playButton(config: KSVideoPlayer.Coordinator) -> some View {
+        Button {
+            if config.state.isPlaying {
+                config.playerLayer?.pause()
+            } else {
+                config.playerLayer?.play()
+            }
+        } label: {
+            Image(systemName: config.state == .error ? "play.slash.fill" : (config.state.isPlaying ? pauseSystemName : playSystemName))
+                .font(.largeTitle)
+        }
+        #if !os(tvOS)
+        .keyboardShortcut(.space, modifiers: .none)
         #endif
     }
 }

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -81,6 +81,16 @@ enum KSVideoPlayerViewBuilder {
                 .opacity(config.state == .buffering ? 1 : 0)
         }
     }
+    
+    @MainActor
+    static func muteButton(config: KSVideoPlayer.Coordinator) -> some View {
+        Button {
+            config.isMuted.toggle()
+        } label: {
+            Image(systemName: config.isMuted ? speakerDisabledSystemName : speakerSystemName)
+        }
+        .shadow(color: .black, radius: 1)
+    }
 }
 
 private extension KSVideoPlayerViewBuilder {
@@ -98,6 +108,23 @@ private extension KSVideoPlayerViewBuilder {
         "pause"
         #else
         "pause.circle.fill"
+        #endif
+    }
+    
+    
+    static var speakerSystemName: String {
+        #if os(xrOS)
+        "speaker.fill"
+        #else
+        "speaker.wave.2.circle.fill"
+        #endif
+    }
+
+    static var speakerDisabledSystemName: String {
+        #if os(xrOS)
+        "speaker.slash.fill"
+        #else
+        "speaker.slash.circle.fill"
         #endif
     }
     

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -91,6 +91,18 @@ enum KSVideoPlayerViewBuilder {
         }
         .shadow(color: .black, radius: 1)
     }
+    
+    static func infoButton(showVideoSetting: Binding<Bool>) -> some View {
+        Button {
+            showVideoSetting.wrappedValue.toggle()
+        } label: {
+            Image(systemName: "info.circle.fill")
+        }
+        // iOS 模拟器加keyboardShortcut会导致KSVideoPlayer.Coordinator无法释放。真机不会有这个问题
+        #if !os(tvOS)
+        .keyboardShortcut("i", modifiers: [.command])
+        #endif
+    }
 }
 
 private extension KSVideoPlayerViewBuilder {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -1,0 +1,83 @@
+//
+//  KSVideoPlayerViewBuilder.swift
+//
+//
+//  Created by Ian Magallan Bosch on 17.03.24.
+//
+
+import SwiftUI
+
+enum KSVideoPlayerViewBuilder {
+    
+    @MainActor
+    static func playbackControlView(config: KSVideoPlayer.Coordinator) -> some View {
+        HStack {
+            Spacer()
+            if config.playerLayer?.player.seekable ?? false {
+                Button {
+                    config.skip(interval: -15)
+                } label: {
+                    Image(systemName: "gobackward.15")
+                        .font(.largeTitle)
+                }
+                #if !os(tvOS)
+                .keyboardShortcut(.leftArrow, modifiers: .none)
+                #endif
+            }
+            Spacer()
+            Button {
+                if config.state.isPlaying {
+                    config.playerLayer?.pause()
+                } else {
+                    config.playerLayer?.play()
+                }
+            } label: {
+                Image(systemName: config.state == .error ? playSlashSystemName : (config.state.isPlaying ? pauseSystemName : playSystemName))
+                    .font(.largeTitle)
+            }
+            #if !os(tvOS)
+            .keyboardShortcut(.space, modifiers: .none)
+            #endif
+            Spacer()
+            if config.playerLayer?.player.seekable ?? false {
+                Button {
+                    config.skip(interval: 15)
+                } label: {
+                    Image(systemName: "goforward.15")
+                        .font(.largeTitle)
+                }
+                #if !os(tvOS)
+                .keyboardShortcut(.rightArrow, modifiers: .none)
+                #endif
+            }
+            Spacer()
+        }
+    }
+}
+
+private extension KSVideoPlayerViewBuilder {
+    
+    private static var playSlashSystemName: String {
+        #if os(xrOS)
+        "play.slash"
+        #else
+        "play.slash.fill"
+        #endif
+    }
+
+    private static var playSystemName: String {
+        #if os(xrOS)
+        "play"
+        #else
+        "play.circle.fill"
+        #endif
+    }
+
+    private static var pauseSystemName: String {
+        #if os(xrOS)
+        "pause"
+        #else
+        "pause.circle.fill"
+        #endif
+    }
+}

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -32,7 +32,7 @@ enum KSVideoPlayerViewBuilder {
                     config.playerLayer?.play()
                 }
             } label: {
-                Image(systemName: config.state == .error ? playSlashSystemName : (config.state.isPlaying ? pauseSystemName : playSystemName))
+                Image(systemName: config.state == .error ? "play.slash.fill" : (config.state.isPlaying ? pauseSystemName : playSystemName))
                     .font(.largeTitle)
             }
             #if !os(tvOS)
@@ -53,27 +53,28 @@ enum KSVideoPlayerViewBuilder {
             Spacer()
         }
     }
+    
+    @MainActor
+    static func contentModeButton(config: KSVideoPlayer.Coordinator) -> some View {
+        Button {
+            config.isScaleAspectFill.toggle()
+        } label: {
+            Image(systemName: config.isScaleAspectFill ? "rectangle.arrowtriangle.2.inward" : "rectangle.arrowtriangle.2.outward")
+        }
+    }
 }
 
 private extension KSVideoPlayerViewBuilder {
-    
-    private static var playSlashSystemName: String {
-        #if os(xrOS)
-        "play.slash"
-        #else
-        "play.slash.fill"
-        #endif
-    }
 
-    private static var playSystemName: String {
+    static var playSystemName: String {
         #if os(xrOS)
-        "play"
+        "play.fill"
         #else
         "play.circle.fill"
         #endif
     }
 
-    private static var pauseSystemName: String {
+    static var pauseSystemName: String {
         #if os(xrOS)
         "pause"
         #else

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -37,6 +37,27 @@ enum KSVideoPlayerViewBuilder {
             Image(systemName: config.isScaleAspectFill ? "rectangle.arrowtriangle.2.inward" : "rectangle.arrowtriangle.2.outward")
         }
     }
+    
+    @MainActor
+    static func subtitleButton(config: KSVideoPlayer.Coordinator) -> some View {
+        MenuView(selection: Binding {
+            config.subtitleModel.selectedSubtitleInfo?.subtitleID
+        } set: { value in
+            let info = config.subtitleModel.subtitleInfos.first { $0.subtitleID == value }
+            config.subtitleModel.selectedSubtitleInfo = info
+            if let info = info as? MediaPlayerTrack {
+                // 因为图片字幕想要实时的显示，那就需要seek。所以需要走select track
+                config.playerLayer?.player.select(track: info)
+            }
+        }) {
+            Text("Off").tag(nil as String?)
+            ForEach(config.subtitleModel.subtitleInfos, id: \.subtitleID) { track in
+                Text(track.name).tag(track.subtitleID as String?)
+            }
+        } label: {
+            Image(systemName: "text.bubble.fill")
+        }
+    }
 }
 
 private extension KSVideoPlayerViewBuilder {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -105,7 +105,7 @@ private extension KSVideoPlayerViewBuilder {
 
     static var pauseSystemName: String {
         #if os(xrOS)
-        "pause"
+        "pause.fill"
         #else
         "pause.circle.fill"
         #endif
@@ -172,6 +172,9 @@ private extension KSVideoPlayerViewBuilder {
             Image(systemName: config.state == .error ? "play.slash.fill" : (config.state.isPlaying ? pauseSystemName : playSystemName))
                 .font(.largeTitle)
         }
+        #if os(xrOS)
+           .contentTransition(.symbolEffect(.replace))
+        #endif
         #if !os(tvOS)
         .keyboardShortcut(.space, modifiers: .none)
         #endif


### PR DESCRIPTION
After implementing KSPlayer in my visionOS app, I noticed that the UI could be aligned a little more on how other apps (e.g. Juno for youtube) look like, taking benefit of the newly introduced ornaments and glassBackground styles.

My initial proposal for it, was written here: https://github.com/kingslay/KSPlayer/discussions/751

Features: 
* Most controls (title, playback buttons, video timer, content mode, subtitles, playback rate and info) have been moved to a bottom-attached ornament.
* Volume has been enhanced. Now it uses a slider so users can set the volume level that they want. 
* The sheet that was presented when tapping the info button was broken on visionOS, you could open it up, but it wasn't possible to dismiss it. Now it uses the same "Done" button as macOS.

<img src="https://github.com/kingslay/KSPlayer/assets/24428301/0072efc2-d1c9-4bf4-af0c-784bb34b3761" width="600"/>
<img src="https://github.com/kingslay/KSPlayer/assets/24428301/6117ddd3-086a-4c8c-b178-dc77f57dbb04" width="600"/>

Changes done here shouldn't affect other platforms and should only apply to visionOS