### PR TITLE
[Fix] Add availability checks

### DIFF
--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -259,7 +259,9 @@ public struct KSVideoPlayerView: View {
         .buttonStyle(.plain)
         .padding(.vertical, 24)
         .padding(.horizontal, 36)
+        #if os(xrOS)
         .glassBackgroundEffect()
+        #endif
     }
     
     private func ornamentControlsView(playerWidth: Double) -> some View {

--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerViewBuilder.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 enum KSVideoPlayerViewBuilder {
     
     @MainActor
@@ -105,6 +106,7 @@ enum KSVideoPlayerViewBuilder {
     }
 }
 
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 private extension KSVideoPlayerViewBuilder {
 
     static var playSystemName: String {


### PR DESCRIPTION
In my previous PR, I forgot to build the project for macOS and iOS, which failed on compile because I forgot to use availability checks and compiler flags for .glassBackgroundEffect() accordingly