### PR TITLE
修复不带序号的VTT字幕解析失败并且代码进入死循环的问题

### DIFF
--- a/Sources/KSPlayer/Subtitle/KSParseProtocol.swift
+++ b/Sources/KSPlayer/Subtitle/KSParseProtocol.swift
@@ -368,17 +368,16 @@ public class VTTParse: KSParseProtocol {
      简中封装 by Q66
      */
     public func parsePart(scanner: Scanner) -> SubtitlePart? {
-        var decimal: String?
+        var timeStrs: String?
         repeat {
-            decimal = scanner.scanUpToCharacters(from: .newlines)
+            timeStrs = scanner.scanUpToCharacters(from: .newlines)
             _ = scanner.scanCharacters(from: .newlines)
-        } while decimal.flatMap(Int.init) == nil
-        let startString = scanner.scanUpToString("-->")
-        // skip spaces and newlines by default.
-        _ = scanner.scanString("-->")
-        if let startString,
-           let endString = scanner.scanUpToCharacters(from: .newlines)
-        {
+        } while !(timeStrs?.contains("-->") ?? false) && !scanner.isAtEnd
+        guard let timeStrs else { return nil }
+        let timeArray: [String] = timeStrs.components(separatedBy: "-->")
+        if timeArray.count == 2{
+            let startString = timeArray[0]
+            let endString = timeArray[1]
             _ = scanner.scanCharacters(from: .newlines)
             var text = ""
             var newLine: String? = nil


### PR DESCRIPTION
有些VTT字幕是没有序号的，
while decimal.flatMap(Int.init) == nil
这段代码直接导致解析失败并且进入死循环

字幕文件：
[How to stay calm when you know you'll be stressed - Daniel Levitin - TED_2_.txt](https://github.com/kingslay/KSPlayer/files/14873950/How.to.stay.calm.when.you.know.you.ll.be.stressed.-.Daniel.Levitin.-.TED_2_.txt)
