### PR TITLE
修复字幕图片过大导致屏幕无法点击的问题

### DIFF
--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -60,6 +60,7 @@ public struct KSVideoPlayerView: View {
                 HStack {
                     Spacer()
                     VideoSubtitleView(model: playerCoordinator.subtitleModel)
+                        .allowsHitTesting(false)//禁止字幕视图交互，以免抢占视图的点击事件或其它手势事件
                     Spacer()
                 }
                 .padding()


### PR DESCRIPTION
有些字幕图片非常大，是1920x1080，虽然里面的字幕文字只占其中一部分，周围的透明部分仍然抢占了界面的交换，导致界面无法点击。   这样改可以让所有字幕显示时都不影响界面的操作。
VideoSubtitleView(model: playerCoordinator.subtitleModel)
                        .allowsHitTesting(false)