### PR TITLE
修复字幕未及时清除的问题

### DIFF
--- a/Sources/KSPlayer/MEPlayer/SubtitleDecode.swift
+++ b/Sources/KSPlayer/MEPlayer/SubtitleDecode.swift
@@ -62,7 +62,10 @@ class SubtitleDecode: DecodeProtocol {
             preSubtitleFrame.part.end = start
         }
         preSubtitleFrame = nil
-        let parts = text(subtitle: subtitle)
+        var parts = text(subtitle: subtitle)
+        if parts.count == 0{
+            parts.append(SubtitlePart(0, 0, attributedString: nil))
+        }
         for part in parts {
             part.start = start
             part.end = start + duration


### PR DESCRIPTION
有时候解码出字幕，但是字幕无内容也需要及时刷新。
不然会出现人物已经很久没说话了，但是字幕却一直显示的问题。

这个修改主要是用来处理preSubtitleFrame.part.end == preSubtitleFrame.part.start的这种没有持续时间的字幕，可以再加一个preSubtitleFrame.part.end == preSubtitleFrame.part.start判断，不加其实也没有影响。





题外话：
第一段代码
extension FFmpegAssetTrack: KSSubtitleProtocol {
    public func search(for time: TimeInterval) -> [SubtitlePart] {
        subtitle?.outputRenderQueue.search { item -> Bool in
            item.part < time || item.part == time
        }.map(\.part) ?? []
    }
}
第二段代码：
     if let subtile = selectedSubtitleInfo {
            let currentTime = currentTime - subtile.delay - subtitleDelay
            newParts = subtile.search(for: currentTime)
            if newParts.isEmpty {
                newParts = parts.filter { part in
                    part.end <= part.start || part == currentTime
                }
            }
        }


我觉得对于那种没有duration的字幕，视频文件中应该会提供一个空字幕来进行清除（我提交的这段代码）。
可以把duration设置为无限长或者长一点的时间比如5秒，然后用空字幕进行清除。
而不用像第一段代码和第二段代码那样去判断item.part < time或者是part.end <= part.start。以及preSubtitleFrame这个都可以去掉了。