### PR TITLE
fix open local subtitle

### DIFF
--- a/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
+++ b/Sources/KSPlayer/SwiftUI/KSVideoPlayerView.swift
@@ -303,12 +303,12 @@ public struct KSVideoPlayerView: View {
 
     public func openURL(_ url: URL) {
         runOnMainThread {
-            if url.isAudio || url.isMovie {
-                self.url = url
-                title = url.lastPathComponent
-            } else {
+            if url.isSubtitle {
                 let info = URLSubtitleInfo(url: url)
                 playerCoordinator.subtitleModel.selectedSubtitleInfo = info
+            } else if url.isAudio || url.isMovie {
+                self.url = url
+                title = url.lastPathComponent
             }
         }
     }


### PR DESCRIPTION
Importing a local SRT subtitle file will be recognized as a video.