### PR TITLE
Add option to disable BrightnessVolume overlay from responding to system changes

### DIFF
--- a/Sources/KSPlayer/Video/BrightnessVolume.swift
+++ b/Sources/KSPlayer/Video/BrightnessVolume.swift
@@ -15,6 +15,7 @@ open class BrightnessVolume {
     init() {
         #if !os(tvOS) && !os(xrOS)
         brightnessObservation = UIScreen.main.observe(\.brightness, options: .new) { [weak self] _, change in
+            guard KSOptions.enableBrightnessGestures else { return }
             if let self, let value = change.newValue {
                 self.appearView()
                 self.progressView.setProgress(Float(value), type: 0)
@@ -31,6 +32,7 @@ open class BrightnessVolume {
     }
 
     @objc private func volumeIsChanged(notification: NSNotification) {
+        guard KSOptions.enableVolumeGestures else { return }
         if let changeReason = notification.userInfo?["AVSystemController_AudioVolumeChangeReasonNotificationParameter"] as? String, changeReason == "ExplicitVolumeChange" {
             if let volume = notification.userInfo?["AVSystemController_AudioVolumeNotificationParameter"] as? CGFloat {
                 appearView()


### PR DESCRIPTION
## Problem

The `BrightnessVolume` class observes system-level brightness and volume changes, displaying an overlay whenever these values change—regardless of whether `KSOptions.enableBrightnessGestures` and `KSOptions.enableVolumeGestures` are enabled.

This causes the overlay to appear when:
- Changing brightness/volume programmatically (e.g., via JavaScript)
- Using Control Center or hardware buttons
- Even when gesture features are explicitly disabled

## Solution

Added guard checks to respect the existing `KSOptions` settings:
- Brightness observer now checks `KSOptions.enableBrightnessGestures`
- Volume notification handler now checks `KSOptions.enableVolumeGestures`

This makes the behavior consistent—disabling these options now also prevents the overlay from appearing on system-level changes.