### PR TITLE
Bug: Crash on invalid display matrix rotation in KSPlayer (FFmpegAssetTrack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ To experience the powerful features of the LGPL version, you can download the ap
 
 | Feature     | LGPL      | GPL    |
 | ----------- | --------- | ------ |
+|Video upscaling |💰|❌|
+|Precache data to Hard Drive|💰|❌|
+|Video switching with zero delay|💰|❌|
+|Audio Passthrough Output by Wi-Fi|💰|❌|
+|Dovi P5 displays HDR (not overheating)|💰|❌|
+|Live streaming supports rewind viewing|💰|❌|
+|ISO Blu-ray disc playback on all Apple platforms|💰|❌|
+|Simultaneous playback of separate audio and video URLs|💰|❌|
+|Offline AI real-time subtitle generation and translation|💰|❌|
+|ProAVPlayer supports MKV, native Dolby Vision and Dolby Atmos.|💰|❌|
+|Play videos in a small window in the App (resumable, supports iOS and tvOS)|💰|❌|
 |Dolby AC-4|✅|❌|
 |Swift Concurrency|✅|❌|
 |AV1 hardware decoding|✅|❌|
@@ -44,17 +55,6 @@ To experience the powerful features of the LGPL version, you can download the ap
 |KSMEPlayer supports all demuxing and decoding formats|✅|❌|
 |Full display of ass subtitles effect(Render as image using libass)|✅|❌|
 |FFmpeg version|8.1.0|6.1.0|
-|Video upscaling |💰|❌|
-|Precache data to Hard Drive|💰|❌|
-|Video switching with zero delay|💰|❌|
-|Audio Passthrough Output by Wi-Fi|💰|❌|
-|Dovi P5 displays HDR (not overheating)|💰|❌|
-|Live streaming supports rewind viewing|💰|❌|
-|ISO Blu-ray disc playback on all Apple platforms|💰|❌|
-|Simultaneous playback of separate audio and video URLs|💰|❌|
-|Offline AI real-time subtitle generation and translation|💰|❌|
-|ProAVPlayer supports MKV, native Dolby Vision and Dolby Atmos.|💰|❌|
-|Play videos in a small window in the App (resumable, supports iOS and tvOS)|💰|❌|
 |Record video|✅|✅|
 |360° panorama video|✅|✅|
 |Picture in Picture|✅|✅|
@@ -74,7 +74,9 @@ To experience the powerful features of the LGPL version, you can download the ap
 
 - iOS 13+, macOS 10.15+, tvOS 13+, xrOS 1+
 
-## The list of App using this SDK
+## List of Apps Licensed to Use this SDK
+
+This table does not list all licensed apps. If you would like to have your app listed above, please send me an email.
 | App Store Link | Logo |
 | -------------- | ---- |
 |[APTV](https://apps.apple.com/app/aptv/id1630403500)||
@@ -87,7 +89,7 @@ To experience the powerful features of the LGPL version, you can download the ap
 |[Spatial Video Studio](https://apps.apple.com/app/id6523429904)||
 |[SWIPTV - IPTV Smart Player](https://apps.apple.com/app/swiptv-iptv-smart-player/id1658538188)||
 |[TracyPlayer](https://apps.apple.com/app/tracyplayer/id6450770064)||
-|[UHF - Love your IPTV](https://apps.apple.com/app/uhf-love-your-iptv/id6443751726)|![logo](https://uhf-web.vercel.app/uhfsponsor.png)|
+|[UHF - Love your IPTV](https://apps.apple.com/app/uhf-love-your-iptv/id6443751726)||
 |[Zen IPTV](https://apps.apple.com/fr/app/zen-iptv/id6458223193)||
 
 

--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ To experience the powerful features of the LGPL version, you can download the ap
 |Video upscaling |💰|❌|
 |Precache data to Hard Drive|💰|❌|
 |Video switching with zero delay|💰|❌|
+|Audio Passthrough Output by Wi-Fi|💰|❌|
 |Dovi P5 displays HDR (not overheating)|💰|❌|
 |Live streaming supports rewind viewing|💰|❌|
 |ISO Blu-ray disc playback on all Apple platforms|💰|❌|
 |Simultaneous playback of separate audio and video URLs|💰|❌|
 |Offline AI real-time subtitle generation and translation|💰|❌|
 |ProAVPlayer supports MKV, native Dolby Vision and Dolby Atmos.|💰|❌|
-|Play videos in a small window in the App (resumable, supports macOS、iOS and tvOS)|💰|❌|
+|Play videos in a small window in the App (resumable, supports iOS and tvOS)|💰|❌|
 |Record video|✅|✅|
 |360° panorama video|✅|✅|
 |Picture in Picture|✅|✅|

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To experience the powerful features of the LGPL version, you can download the ap
 |ISO Blu-ray disc playback on all Apple platforms|💰|❌|
 |Simultaneous playback of separate audio and video URLs|💰|❌|
 |Offline AI real-time subtitle generation and translation|💰|❌|
+|ProAVPlayer supports MKV, native Dolby Vision and Dolby Atmos.|💰|❌|
 |Play videos in a small window in the App (resumable, supports macOS、iOS and tvOS)|💰|❌|
 |Record video|✅|✅|
 |360° panorama video|✅|✅|

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ To experience the powerful features of the LGPL version, you can download the ap
 |Swift Concurrency|✅|❌|
 |AV1 hardware decoding|✅|❌|
 |Word-by-word subtitles|✅|❌|
-|All demuxers, All decoders|✅|❌|
 |Use System Caption Appearance|✅|❌|
 |Record video clips at any time|✅|❌|
 |Smoothly Play 8K or 120 FPS Video|✅|❌|
@@ -42,8 +41,9 @@ To experience the powerful features of the LGPL version, you can download the ap
 |Annex-B async hardware decoding(Live Stream)|✅|❌|
 |Use the fonts in the video to render subtitles|✅|❌|
 |Use memory cache for fast seek in short time range|✅|❌|
+|KSMEPlayer supports all demuxing and decoding formats|✅|❌|
 |Full display of ass subtitles effect(Render as image using libass)|✅|❌|
-|FFmpeg version|8.0.1|6.1.0|
+|FFmpeg version|8.1.0|6.1.0|
 |Video upscaling |💰|❌|
 |Precache data to Hard Drive|💰|❌|
 |Video switching with zero delay|💰|❌|

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To experience the powerful features of the LGPL version, you can download the ap
 | Feature     | LGPL      | GPL    |
 | ----------- | --------- | ------ |
 |Video upscaling |💰|❌|
+|ProgressBar Preview |💰|❌|
 |Precache data to Hard Drive|💰|❌|
 |Video switching with zero delay|💰|❌|
 |Audio Passthrough Output by Wi-Fi|💰|❌|
@@ -42,6 +43,7 @@ To experience the powerful features of the LGPL version, you can download the ap
 |Swift Concurrency|✅|❌|
 |AV1 hardware decoding|✅|❌|
 |Word-by-word subtitles|✅|❌|
+|Text subtitle translation|✅|❌|
 |Use System Caption Appearance|✅|❌|
 |Record video clips at any time|✅|❌|
 |Smoothly Play 8K or 120 FPS Video|✅|❌|

--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ To experience the powerful features of the LGPL version, you can download the ap
 |Use System Caption Appearance|✅|❌|
 |Record video clips at any time|✅|❌|
 |Smoothly Play 8K or 120 FPS Video|✅|❌|
+|Display Subtitles with HDR Effects|✅|❌|
 |Video download and format conversion|✅|❌|
 |External image subtitles, such as SUP|✅|❌|
 |Main subtitles and Secondary subtitles|✅|❌|
+|Adjust Saturation, Brightness, and Contrast|✅|❌|
 |Picture in Picture supports subtitle display|✅|❌|
 |Annex-B async hardware decoding(Live Stream)|✅|❌|
 |Use the fonts in the video to render subtitles|✅|❌|

--- a/Sources/KSPlayer/MEPlayer/AudioRendererPlayer.swift
+++ b/Sources/KSPlayer/MEPlayer/AudioRendererPlayer.swift
@@ -49,9 +49,9 @@ public class AudioRendererPlayer: AudioOutput {
         if #available(macOS 11.3, iOS 14.5, tvOS 14.5, *) {
             synchronizer.delaysRateChangeUntilHasSufficientMediaData = false
         }
-//        if #available(tvOS 15.0, iOS 15.0, macOS 12.0, *) {
-//            renderer.allowedAudioSpatializationFormats = .monoStereoAndMultichannel
-//        }
+        if #available(tvOS 15.0, iOS 15.0, macOS 12.0, *) {
+            renderer.allowedAudioSpatializationFormats = .monoStereoAndMultichannel
+        }
     }
 
     public func prepare(audioFormat: AVAudioFormat) {

--- a/Sources/KSPlayer/MEPlayer/AudioRendererPlayer.swift
+++ b/Sources/KSPlayer/MEPlayer/AudioRendererPlayer.swift
@@ -133,7 +133,7 @@ public class AudioRendererPlayer: AudioOutput {
                 renderer.audioTimePitchAlgorithm = channelCount > 2 ? .spectral : .timeDomain
                 renderer.enqueue(sampleBuffer)
                 #if !os(macOS)
-                if AVAudioSession.sharedInstance().preferredInputNumberOfChannels != channelCount {
+                if AVAudioSession.sharedInstance().preferredOutputNumberOfChannels != channelCount {
                     try? AVAudioSession.sharedInstance().setPreferredOutputNumberOfChannels(Int(channelCount))
                 }
                 #endif

--- a/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
@@ -168,7 +168,14 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
                         dovi = sideData.data.withMemoryRebound(to: DOVIDecoderConfigurationRecord.self, capacity: 1) { $0 }.pointee
                     } else if sideData.type == AV_PKT_DATA_DISPLAYMATRIX {
                         let matrix = sideData.data.withMemoryRebound(to: Int32.self, capacity: 1) { $0 }
-                        rotation = Int16(Int(-av_display_rotation_get(matrix)) % 360)
+                        let rawRotation = -av_display_rotation_get(matrix)
+                        if rawRotation.isFinite {
+                            let degrees = Int(rawRotation.rounded())
+                            let normalized = ((degrees % 360) + 360) % 360
+                            rotation = Int16(normalized)
+                        } else {
+                            rotation = 0
+                        }                        
                     }
                 }
             }


### PR DESCRIPTION
Problem
In FFmpegAssetTrack, rotation is parsed from AV_PKT_DATA_DISPLAYMATRIX and converted directly to Int:

rotation = Int16(Int(-av_display_rotation_get(matrix)) % 360)
For some streams, av_display_rotation_get(matrix) returns non-finite values (NaN / Infinity), which causes a runtime fatal error on Int(...) conversion:

Fatal error: Double value cannot be converted to Int because it is either infinite or NaN

Root Cause
No validation of Double finiteness before integer conversion.

Fix
Validate rotation value with isFinite before converting to Int.
Normalize finite values to [0, 359].
Fallback to 0 for invalid values.
Why this change
Prevents hard crash on malformed/invalid display matrix metadata and makes playback startup more robust for edge-case streams.

Impact
✅ Eliminates this crash path during media open.
✅ Keeps valid rotation behavior intact.
✅ Safe fallback for corrupted metadata.
Repro (before fix)
Open a stream/file containing invalid display matrix rotation metadata.
Player reaches FFmpegAssetTrack display matrix parsing.
App crashes with fatal Double -> Int conversion error.
Behavior after fix
Same stream opens without crash; rotation defaults safely when metadata is invalid.