### PR TITLE
Fix crash in KSPlayer when reading video rotation from FFmpeg display matrix metadata.

### DIFF
--- a/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
@@ -168,7 +168,14 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
                         dovi = sideData.data.withMemoryRebound(to: DOVIDecoderConfigurationRecord.self, capacity: 1) { $0 }.pointee
                     } else if sideData.type == AV_PKT_DATA_DISPLAYMATRIX {
                         let matrix = sideData.data.withMemoryRebound(to: Int32.self, capacity: 1) { $0 }
-                        rotation = Int16(Int(-av_display_rotation_get(matrix)) % 360)
+                        let rawRotation = -av_display_rotation_get(matrix)
+                        if rawRotation.isFinite {
+                            let degrees = Int(rawRotation.rounded())
+                            let normalized = ((degrees % 360) + 360) % 360
+                            rotation = Int16(normalized)
+                        } else {
+                            rotation = 0
+                        }                        
                     }
                 }
             }


### PR DESCRIPTION
Problem
In FFmpegAssetTrack, rotation is parsed from AV_PKT_DATA_DISPLAYMATRIX and converted directly to Int:

rotation = Int16(Int(-av_display_rotation_get(matrix)) % 360)
For some streams, av_display_rotation_get(matrix) returns non-finite values (NaN / Infinity), which causes a runtime fatal error on Int(...) conversion:

Fatal error: Double value cannot be converted to Int because it is either infinite or NaN

Root Cause
No validation of Double finiteness before integer conversion.

Fix
Validate rotation value with isFinite before converting to Int.
Normalize finite values to [0, 359].
Fallback to 0 for invalid values.
Why this change
Prevents hard crash on malformed/invalid display matrix metadata and makes playback startup more robust for edge-case streams.

Impact
✅ Eliminates this crash path during media open.
✅ Keeps valid rotation behavior intact.
✅ Safe fallback for corrupted metadata.
Repro (before fix)
Open a stream/file containing invalid display matrix rotation metadata.
Player reaches FFmpegAssetTrack display matrix parsing.
App crashes with fatal Double -> Int conversion error.
Behavior after fix
Same stream opens without crash; rotation defaults safely when metadata is invalid.