### PR TITLE
Guard NULL codecpar instead of force-unwrapping (fixes crash on streams with no parser)

### DIFF
--- a/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
@@ -69,7 +69,12 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
     }
 
     convenience init?(stream: UnsafeMutablePointer<AVStream>) {
-        let codecpar = stream.pointee.codecpar.pointee
+        // `codecpar` is imported as an implicitly unwrapped optional, but
+        // FFmpeg leaves it NULL for streams it has no parser for (e.g. the
+        // `bin_data` streams present in many DVB/MPEG-TS muxes). This
+        // initialiser is already failable, so skip the stream rather than
+        // trapping — createCodec's compactMap drops it.
+        guard let codecpar = stream.pointee.codecpar?.pointee else { return nil }
         self.init(codecpar: codecpar)
         self.stream = stream
         let metadata = toDictionary(stream.pointee.metadata)

--- a/Sources/KSPlayer/MEPlayer/MEPlayerItem.swift
+++ b/Sources/KSPlayer/MEPlayer/MEPlayerItem.swift
@@ -290,7 +290,10 @@ extension MEPlayerItem {
         let formatName = outputFormatCtx.pointee.oformat.pointee.name.flatMap { String(cString: $0) }
         for i in 0 ..< Int(formatCtx.pointee.nb_streams) {
             if let inputStream = formatCtx.pointee.streams[i] {
-                let codecType = inputStream.pointee.codecpar.pointee.codec_type
+                // Same NULL-codecpar hazard as FFmpegAssetTrack.init(stream:);
+                // this loop also visits every stream in the container.
+                guard let inputCodecpar = inputStream.pointee.codecpar else { continue }
+                let codecType = inputCodecpar.pointee.codec_type
                 if [AVMEDIA_TYPE_AUDIO, AVMEDIA_TYPE_VIDEO, AVMEDIA_TYPE_SUBTITLE].contains(codecType) {
                     if codecType == AVMEDIA_TYPE_AUDIO {
                         if let audioIndex {


### PR DESCRIPTION
Playing an MPEG-TS stream that contains a `bin_data` stream crashes the process:

```
KSPlayer/FFmpegAssetTrack.swift:72: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
```

Thread: `KSPlayer_MEPlayerItem_open`
```
closure #1 in MEPlayerItem.createCodec(formatCtx:)
compactMap
MEPlayerItem.createCodec(formatCtx:)
MEPlayerItem.openThread()
closure #1 in MEPlayerItem.prepareToPlay()
```

Preceded in the log by:
```
error KSPlayer: MEPlayerItem.swift:117 MEPlayerItem | parser not found for codec bin_data, packets or times may be invalid.
```

### Cause

`AVStream.codecpar` is imported into Swift as an implicitly unwrapped optional (`UnsafeMutablePointer<AVCodecParameters>!`), but FFmpeg legitimately leaves it NULL for streams it has no parser for. `bin_data` streams inside DVB-sourced MPEG-TS muxes are the common real-world case — plenty of IPTV/DVB channels carry one.

`createCodec` builds an `FFmpegAssetTrack` for **every** stream in the container via `compactMap`, so one such stream is enough to trap the whole process. There is no option to skip it, since the track is constructed before any filtering.

This is not recoverable by the host app: a Swift force-unwrap trap cannot be caught. On tvOS it wedges the app badly enough that the device needs a power cycle.

### Fix

`FFmpegAssetTrack.init(stream:)` is already a failable initialiser, so it returns `nil` and the existing `compactMap` simply drops the unusable stream — playback continues with the audio/video tracks as normal.

The identical hazard on `MEPlayerItem`'s record/remux stream loop (which also walks every stream) is guarded with `continue`.

Two lines of behaviour change, no API change. Both `2.3.4` and current `main` are affected.