### PR TITLE
Fix mastering display metadata cast crash

### DIFF
--- a/Sources/KSPlayer/MEPlayer/FFmpegDecode.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegDecode.swift
@@ -35,9 +35,18 @@ class FFmpegDecode: DecodeProtocol {
     }
 
     func decodeFrame(from packet: Packet, completionHandler: @escaping (Result<MEFrame, Error>) -> Void) {
+        func uint16BigEndian(_ value: Int32) -> UInt16? {
+            UInt16(exactly: value)?.bigEndian
+        }
+
+        func uint32BigEndian(_ value: Int32) -> UInt32? {
+            UInt32(exactly: value)?.bigEndian
+        }
+
         guard let codecContext, avcodec_send_packet(codecContext, packet.corePacket) == 0 else {
             return
         }
+
         // 需要avcodec_send_packet之后，properties的值才会变成FF_CODEC_PROPERTY_CLOSED_CAPTIONS
         if packet.assetTrack.mediaType == .video {
             if Int32(codecContext.pointee.properties) & FF_CODEC_PROPERTY_CLOSED_CAPTIONS != 0, packet.assetTrack.closedCaptionsTrack == nil {
@@ -55,12 +64,14 @@ class FFmpegDecode: DecodeProtocol {
                 }
             }
         }
+
         while true {
             let result = avcodec_receive_frame(codecContext, coreFrame)
             if result == 0, let inputFrame = coreFrame {
                 var displayData: MasteringDisplayMetadata?
                 var contentData: ContentLightMetadata?
                 var ambientViewingEnvironment: AmbientViewingEnvironment?
+
                 // filter之后，side_data信息会丢失，所以放在这里
                 if inputFrame.pointee.nb_side_data > 0 {
                     for i in 0 ..< inputFrame.pointee.nb_side_data {
@@ -98,42 +109,67 @@ class FFmpegDecode: DecodeProtocol {
                                 let header = av_dovi_get_header(data)
                                 let mapping = av_dovi_get_mapping(data)
                                 let color = av_dovi_get_color(data)
-//                                frame.corePixelBuffer?.transferFunction = kCVImageBufferTransferFunction_ITU_R_2020
+                                // frame.corePixelBuffer?.transferFunction = kCVImageBufferTransferFunction_ITU_R_2020
                             } else if sideData.type == AV_FRAME_DATA_DYNAMIC_HDR_PLUS { // AVDynamicHDRPlus
                                 let data = sideData.data.withMemoryRebound(to: AVDynamicHDRPlus.self, capacity: 1) { $0 }.pointee
                             } else if sideData.type == AV_FRAME_DATA_DYNAMIC_HDR_VIVID { // AVDynamicHDRVivid
                                 let data = sideData.data.withMemoryRebound(to: AVDynamicHDRVivid.self, capacity: 1) { $0 }.pointee
                             } else if sideData.type == AV_FRAME_DATA_MASTERING_DISPLAY_METADATA {
                                 let data = sideData.data.withMemoryRebound(to: AVMasteringDisplayMetadata.self, capacity: 1) { $0 }.pointee
-                                displayData = MasteringDisplayMetadata(
-                                    display_primaries_r_x: UInt16(data.display_primaries.0.0.num).bigEndian,
-                                    display_primaries_r_y: UInt16(data.display_primaries.0.1.num).bigEndian,
-                                    display_primaries_g_x: UInt16(data.display_primaries.1.0.num).bigEndian,
-                                    display_primaries_g_y: UInt16(data.display_primaries.1.1.num).bigEndian,
-                                    display_primaries_b_x: UInt16(data.display_primaries.2.1.num).bigEndian,
-                                    display_primaries_b_y: UInt16(data.display_primaries.2.1.num).bigEndian,
-                                    white_point_x: UInt16(data.white_point.0.num).bigEndian,
-                                    white_point_y: UInt16(data.white_point.1.num).bigEndian,
-                                    minLuminance: UInt32(data.min_luminance.num).bigEndian,
-                                    maxLuminance: UInt32(data.max_luminance.num).bigEndian
-                                )
+
+                                if let displayPrimariesRX = uint16BigEndian(data.display_primaries.0.0.num),
+                                   let displayPrimariesRY = uint16BigEndian(data.display_primaries.0.1.num),
+                                   let displayPrimariesGX = uint16BigEndian(data.display_primaries.1.0.num),
+                                   let displayPrimariesGY = uint16BigEndian(data.display_primaries.1.1.num),
+                                   let displayPrimariesBX = uint16BigEndian(data.display_primaries.2.0.num),
+                                   let displayPrimariesBY = uint16BigEndian(data.display_primaries.2.1.num),
+                                   let whitePointX = uint16BigEndian(data.white_point.0.num),
+                                   let whitePointY = uint16BigEndian(data.white_point.1.num),
+                                   let minLuminance = uint32BigEndian(data.min_luminance.num),
+                                   let maxLuminance = uint32BigEndian(data.max_luminance.num)
+                                {
+                                    displayData = MasteringDisplayMetadata(
+                                        display_primaries_r_x: displayPrimariesRX,
+                                        display_primaries_r_y: displayPrimariesRY,
+                                        display_primaries_g_x: displayPrimariesGX,
+                                        display_primaries_g_y: displayPrimariesGY,
+                                        display_primaries_b_x: displayPrimariesBX,
+                                        display_primaries_b_y: displayPrimariesBY,
+                                        white_point_x: whitePointX,
+                                        white_point_y: whitePointY,
+                                        minLuminance: minLuminance,
+                                        maxLuminance: maxLuminance
+                                    )
+                                }
                             } else if sideData.type == AV_FRAME_DATA_CONTENT_LIGHT_LEVEL {
                                 let data = sideData.data.withMemoryRebound(to: AVContentLightMetadata.self, capacity: 1) { $0 }.pointee
-                                contentData = ContentLightMetadata(
-                                    MaxCLL: UInt16(data.MaxCLL).bigEndian,
-                                    MaxFALL: UInt16(data.MaxFALL).bigEndian
-                                )
+
+                                if data.MaxCLL <= UInt16.max,
+                                   data.MaxFALL <= UInt16.max
+                                {
+                                    contentData = ContentLightMetadata(
+                                        MaxCLL: UInt16(data.MaxCLL).bigEndian,
+                                        MaxFALL: UInt16(data.MaxFALL).bigEndian
+                                    )
+                                }
                             } else if sideData.type == AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT {
                                 let data = sideData.data.withMemoryRebound(to: AVAmbientViewingEnvironment.self, capacity: 1) { $0 }.pointee
-                                ambientViewingEnvironment = AmbientViewingEnvironment(
-                                    ambient_illuminance: UInt32(data.ambient_illuminance.num).bigEndian,
-                                    ambient_light_x: UInt16(data.ambient_light_x.num).bigEndian,
-                                    ambient_light_y: UInt16(data.ambient_light_y.num).bigEndian
-                                )
+
+                                if let ambientIlluminance = uint32BigEndian(data.ambient_illuminance.num),
+                                   let ambientLightX = uint16BigEndian(data.ambient_light_x.num),
+                                   let ambientLightY = uint16BigEndian(data.ambient_light_y.num)
+                                {
+                                    ambientViewingEnvironment = AmbientViewingEnvironment(
+                                        ambient_illuminance: ambientIlluminance,
+                                        ambient_light_x: ambientLightX,
+                                        ambient_light_y: ambientLightY
+                                    )
+                                }
                             }
                         }
                     }
                 }
+
                 filter.filter(options: options, inputFrame: inputFrame) { avframe in
                     do {
                         var frame = try frameChange.change(avframe: avframe)
@@ -146,7 +182,7 @@ class FFmpegDecode: DecodeProtocol {
                             }
                         }
                         frame.timebase = filter.timebase
-                        //                frame.timebase = Timebase(avframe.pointee.time_base)
+                        // frame.timebase = Timebase(avframe.pointee.time_base)
                         frame.size = packet.size
                         frame.position = packet.position
                         frame.duration = avframe.pointee.duration

--- a/Sources/KSPlayer/MEPlayer/FFmpegDecode.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegDecode.swift
@@ -35,14 +35,6 @@ class FFmpegDecode: DecodeProtocol {
     }
 
     func decodeFrame(from packet: Packet, completionHandler: @escaping (Result<MEFrame, Error>) -> Void) {
-        func uint16BigEndian(_ value: Int32) -> UInt16? {
-            UInt16(exactly: value)?.bigEndian
-        }
-
-        func uint32BigEndian(_ value: Int32) -> UInt32? {
-            UInt32(exactly: value)?.bigEndian
-        }
-
         guard let codecContext, avcodec_send_packet(codecContext, packet.corePacket) == 0 else {
             return
         }
@@ -116,55 +108,31 @@ class FFmpegDecode: DecodeProtocol {
                                 let data = sideData.data.withMemoryRebound(to: AVDynamicHDRVivid.self, capacity: 1) { $0 }.pointee
                             } else if sideData.type == AV_FRAME_DATA_MASTERING_DISPLAY_METADATA {
                                 let data = sideData.data.withMemoryRebound(to: AVMasteringDisplayMetadata.self, capacity: 1) { $0 }.pointee
-
-                                if let displayPrimariesRX = uint16BigEndian(data.display_primaries.0.0.num),
-                                   let displayPrimariesRY = uint16BigEndian(data.display_primaries.0.1.num),
-                                   let displayPrimariesGX = uint16BigEndian(data.display_primaries.1.0.num),
-                                   let displayPrimariesGY = uint16BigEndian(data.display_primaries.1.1.num),
-                                   let displayPrimariesBX = uint16BigEndian(data.display_primaries.2.0.num),
-                                   let displayPrimariesBY = uint16BigEndian(data.display_primaries.2.1.num),
-                                   let whitePointX = uint16BigEndian(data.white_point.0.num),
-                                   let whitePointY = uint16BigEndian(data.white_point.1.num),
-                                   let minLuminance = uint32BigEndian(data.min_luminance.num),
-                                   let maxLuminance = uint32BigEndian(data.max_luminance.num)
-                                {
-                                    displayData = MasteringDisplayMetadata(
-                                        display_primaries_r_x: displayPrimariesRX,
-                                        display_primaries_r_y: displayPrimariesRY,
-                                        display_primaries_g_x: displayPrimariesGX,
-                                        display_primaries_g_y: displayPrimariesGY,
-                                        display_primaries_b_x: displayPrimariesBX,
-                                        display_primaries_b_y: displayPrimariesBY,
-                                        white_point_x: whitePointX,
-                                        white_point_y: whitePointY,
-                                        minLuminance: minLuminance,
-                                        maxLuminance: maxLuminance
-                                    )
-                                }
+                                displayData = MasteringDisplayMetadata(
+                                    display_primaries_r_x: UInt16(truncatingIfNeeded: data.display_primaries.0.0.num).bigEndian,
+                                    display_primaries_r_y: UInt16(truncatingIfNeeded: data.display_primaries.0.1.num).bigEndian,
+                                    display_primaries_g_x: UInt16(truncatingIfNeeded: data.display_primaries.1.0.num).bigEndian,
+                                    display_primaries_g_y: UInt16(truncatingIfNeeded: data.display_primaries.1.1.num).bigEndian,
+                                    display_primaries_b_x: UInt16(truncatingIfNeeded: data.display_primaries.2.0.num).bigEndian,
+                                    display_primaries_b_y: UInt16(truncatingIfNeeded: data.display_primaries.2.1.num).bigEndian,
+                                    white_point_x: UInt16(truncatingIfNeeded: data.white_point.0.num).bigEndian,
+                                    white_point_y: UInt16(truncatingIfNeeded: data.white_point.1.num).bigEndian,
+                                    minLuminance: UInt32(truncatingIfNeeded: data.min_luminance.num).bigEndian,
+                                    maxLuminance: UInt32(truncatingIfNeeded: data.max_luminance.num).bigEndian
+                                )
                             } else if sideData.type == AV_FRAME_DATA_CONTENT_LIGHT_LEVEL {
                                 let data = sideData.data.withMemoryRebound(to: AVContentLightMetadata.self, capacity: 1) { $0 }.pointee
-
-                                if data.MaxCLL <= UInt16.max,
-                                   data.MaxFALL <= UInt16.max
-                                {
-                                    contentData = ContentLightMetadata(
-                                        MaxCLL: UInt16(data.MaxCLL).bigEndian,
-                                        MaxFALL: UInt16(data.MaxFALL).bigEndian
-                                    )
-                                }
+                                contentData = ContentLightMetadata(
+                                    MaxCLL: UInt16(truncatingIfNeeded: data.MaxCLL).bigEndian,
+                                    MaxFALL: UInt16(truncatingIfNeeded: data.MaxFALL).bigEndian
+                                )
                             } else if sideData.type == AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT {
                                 let data = sideData.data.withMemoryRebound(to: AVAmbientViewingEnvironment.self, capacity: 1) { $0 }.pointee
-
-                                if let ambientIlluminance = uint32BigEndian(data.ambient_illuminance.num),
-                                   let ambientLightX = uint16BigEndian(data.ambient_light_x.num),
-                                   let ambientLightY = uint16BigEndian(data.ambient_light_y.num)
-                                {
-                                    ambientViewingEnvironment = AmbientViewingEnvironment(
-                                        ambient_illuminance: ambientIlluminance,
-                                        ambient_light_x: ambientLightX,
-                                        ambient_light_y: ambientLightY
-                                    )
-                                }
+                                ambientViewingEnvironment = AmbientViewingEnvironment(
+                                    ambient_illuminance: UInt32(truncatingIfNeeded: data.ambient_illuminance.num).bigEndian,
+                                    ambient_light_x: UInt16(truncatingIfNeeded: data.ambient_light_x.num).bigEndian,
+                                    ambient_light_y: UInt16(truncatingIfNeeded: data.ambient_light_y.num).bigEndian
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- replace unchecked mastering display metadata casts with safe exact conversions
- skip malformed mastering display metadata instead of crashing `decodeFrame`
- fix blue primary X metadata to use `display_primaries[2][0]`

## Why
Some MKV streams expose mastering display metadata values that do not fit the
target `UInt16`/`UInt32` fields. Swift traps on conversions like
`UInt16(value)`, which can crash iOS playback during frame decode.

## Testing
- Reproduced the crash on iOS before the change with the affected MKV stream
- Verified the stream no longer crashes after the change