### PR TITLE
Fix divide-by-zero trap in FFmpegAssetTrack audio nominalFrameRate

### DIFF
--- a/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
@@ -96,7 +96,7 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
             nominalFrameRate = Self.audioNominalFrameRate(
                 sampleRate: codecpar.sample_rate,
                 frameSize: codecpar.frame_size,
-                timebase: timebase
+                codecID: codecpar.codec_id
             )
         } else {
             if stream.pointee.duration > 0, stream.pointee.nb_frames > 0, stream.pointee.nb_frames != stream.pointee.duration {
@@ -133,22 +133,19 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
     ///
     /// `AVCodecParameters.frame_size` is audio-only and left at `0` by most
     /// demuxers (AAC/MP3/Opus/FLAC/Vorbis) until the first frame is decoded,
-    /// and the `timebase.den / timebase.num` fallback integer-divides to `0`
-    /// whenever `den < num` (e.g. a valid `AVRational{num:3,den:1}`). Swift
-    /// traps on integer divide-by-zero, so fall back to the existing `48`
-    /// floor rather than crashing — mirroring `AudioDescriptor`'s own
-    /// `sampleRate <= 0` guard (`Resample.swift`).
-    static func audioNominalFrameRate(sampleRate: Int32, frameSize: Int32, timebase: Timebase) -> Float {
-        var frameSize = frameSize
-        // `timebase.num` is guaranteed > 0 by `convenience init?(stream:)`, but
-        // guard it here too so this helper can never trap on a zero divisor.
-        if frameSize < 1, timebase.num > 0 {
-            frameSize = timebase.den / timebase.num
-        }
-        guard frameSize > 0, sampleRate > 0 else {
+    /// and a `0` divisor traps Swift with a divide-by-zero. When it is unset,
+    /// fall back to codec-aware constants (TRUEHD: 48, everything else: 1000)
+    /// instead of deriving a frame size arithmetically. `sample_rate` can also
+    /// be `0` pre-decode, so guard both before dividing — mirroring
+    /// `AudioDescriptor`'s own `sampleRate <= 0` guard (`Resample.swift`).
+    static func audioNominalFrameRate(sampleRate: Int32, frameSize: Int32, codecID: AVCodecID) -> Float {
+        // Suggested by the maintainer: codec-aware fallbacks instead of deriving a
+        // frame size from the stream timebase (whose den/num can integer-divide to 0).
+        let effectiveFrameSize = frameSize > 0 ? frameSize : codecID == AV_CODEC_ID_TRUEHD ? 48 : 1000
+        guard sampleRate > 0, effectiveFrameSize > 0 else {
             return 48
         }
-        return max(Float(sampleRate / frameSize), 48)
+        return max(Float(sampleRate / effectiveFrameSize), 48)
     }
 
     init?(codecpar: AVCodecParameters) {

--- a/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
@@ -93,11 +93,11 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
         avgFrameRate = Timebase(stream.pointee.avg_frame_rate)
         realFrameRate = Timebase(stream.pointee.r_frame_rate)
         if mediaType == .audio {
-            var frameSize = codecpar.frame_size
-            if frameSize < 1 {
-                frameSize = timebase.den / timebase.num
-            }
-            nominalFrameRate = max(Float(codecpar.sample_rate / frameSize), 48)
+            nominalFrameRate = Self.audioNominalFrameRate(
+                sampleRate: codecpar.sample_rate,
+                frameSize: codecpar.frame_size,
+                timebase: timebase
+            )
         } else {
             if stream.pointee.duration > 0, stream.pointee.nb_frames > 0, stream.pointee.nb_frames != stream.pointee.duration {
                 nominalFrameRate = Float(stream.pointee.nb_frames) * Float(timebase.den) / Float(stream.pointee.duration) * Float(timebase.num)
@@ -127,6 +127,28 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
         }
         //        var buf = [Int8](repeating: 0, count: 256)
         //        avcodec_string(&buf, buf.count, codecpar, 0)
+    }
+
+    /// Audio `nominalFrameRate` derived from `sample_rate` / `frame_size`.
+    ///
+    /// `AVCodecParameters.frame_size` is audio-only and left at `0` by most
+    /// demuxers (AAC/MP3/Opus/FLAC/Vorbis) until the first frame is decoded,
+    /// and the `timebase.den / timebase.num` fallback integer-divides to `0`
+    /// whenever `den < num` (e.g. a valid `AVRational{num:3,den:1}`). Swift
+    /// traps on integer divide-by-zero, so fall back to the existing `48`
+    /// floor rather than crashing — mirroring `AudioDescriptor`'s own
+    /// `sampleRate <= 0` guard (`Resample.swift`).
+    static func audioNominalFrameRate(sampleRate: Int32, frameSize: Int32, timebase: Timebase) -> Float {
+        var frameSize = frameSize
+        // `timebase.num` is guaranteed > 0 by `convenience init?(stream:)`, but
+        // guard it here too so this helper can never trap on a zero divisor.
+        if frameSize < 1, timebase.num > 0 {
+            frameSize = timebase.den / timebase.num
+        }
+        guard frameSize > 0, sampleRate > 0 else {
+            return 48
+        }
+        return max(Float(sampleRate / frameSize), 48)
     }
 
     init?(codecpar: AVCodecParameters) {

--- a/Tests/KSPlayerTests/FFmpegAssetTrackTest.swift
+++ b/Tests/KSPlayerTests/FFmpegAssetTrackTest.swift
@@ -1,0 +1,102 @@
+//  FFmpegAssetTrackTest.swift
+//  KSPlayerTests
+//
+//  Trap guard + regression tests for FFmpegAssetTrack.audioNominalFrameRate.
+//
+
+@testable import KSPlayer
+import XCTest
+
+final class FFmpegAssetTrackTest: XCTestCase {
+    /// `AVCodecParameters.frame_size == 0` (left at 0 by most audio demuxers —
+    /// AAC/MP3/Opus/FLAC/Vorbis — until the first frame is decoded) combined
+    /// with a valid `AVRational{num:3,den:1}`: the `timebase.den / timebase.num`
+    /// fallback integer-divides to `0`, so the old inline arithmetic on
+    /// `FFmpegAssetTrack.swift:100` did `sample_rate / 0` and trapped with
+    /// `Fatal error: Division by zero`. The helper must return the `48` floor.
+    func testAudioNominalFrameRateFallbackDividesToZero() {
+        let rate = FFmpegAssetTrack.audioNominalFrameRate(
+            sampleRate: 48000,
+            frameSize: 0,
+            timebase: Timebase(num: 3, den: 1)
+        )
+        XCTAssertEqual(rate, 48, accuracy: 0.001)
+    }
+
+    /// `sample_rate == 0` (also common pre-decode). Two sub-cases:
+    /// - a usable fallback (`den >= num`): historically `0 / 1000 == 0` -> 48;
+    /// - a zero fallback (`den < num`): historically `0 / 0` -> trap.
+    /// Both must now return the `48` floor.
+    func testAudioNominalFrameRateZeroSampleRate() {
+        XCTAssertEqual(
+            FFmpegAssetTrack.audioNominalFrameRate(sampleRate: 0, frameSize: 0, timebase: Timebase(num: 1, den: 1000)),
+            48,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            FFmpegAssetTrack.audioNominalFrameRate(sampleRate: 0, frameSize: 0, timebase: Timebase(num: 3, den: 1)),
+            48,
+            accuracy: 0.001
+        )
+    }
+
+    /// Well-formed stream, unchanged from the pre-fix behaviour:
+    /// `48000 / 1024 == 46` (Int32) -> `max(46, 48) == 48`. Regression guard.
+    func testAudioNominalFrameRateWellFormedClampsToFloor() {
+        let rate = FFmpegAssetTrack.audioNominalFrameRate(
+            sampleRate: 48000,
+            frameSize: 1024,
+            timebase: Timebase(num: 1, den: 1)
+        )
+        XCTAssertEqual(rate, 48, accuracy: 0.001)
+    }
+
+    /// Well-formed stream whose true rate is above the floor, using a
+    /// non-evenly-dividing pair so the assertion pins INTEGER division
+    /// (`48000 / 700 == 68` via Int32 truncation; a `Float / Float` refactor
+    /// would yield ~68.57 and fail this assertion). Exercises the non-floor
+    /// path and proves the arithmetic is byte-for-byte preserved.
+    func testAudioNominalFrameRateAboveFloor() {
+        let rate = FFmpegAssetTrack.audioNominalFrameRate(
+            sampleRate: 48000,
+            frameSize: 700,
+            timebase: Timebase(num: 1, den: 1)
+        )
+        XCTAssertEqual(rate, 68, accuracy: 0.001)
+    }
+
+    /// `frame_size == 0` but the `time_base` fallback is usable (`den >= num`):
+    /// `den / num == 1000`, then `48000 / 1000 == 48` -> floor `48`.
+    func testAudioNominalFrameRateUsesTimebaseFallback() {
+        let rate = FFmpegAssetTrack.audioNominalFrameRate(
+            sampleRate: 48000,
+            frameSize: 0,
+            timebase: Timebase(num: 1, den: 1000)
+        )
+        XCTAssertEqual(rate, 48, accuracy: 0.001)
+    }
+
+    /// `timebase.num == 0`: the helper's `den / num` fallback must be skipped
+    /// (it would divide by zero) and the `48` floor returned. The production
+    /// caller pre-guards `num > 0`, but the helper is exercised directly here,
+    /// so pin that it can never trap on its own.
+    func testAudioNominalFrameRateZeroTimebaseNumDoesNotTrap() {
+        let rate = FFmpegAssetTrack.audioNominalFrameRate(
+            sampleRate: 48000,
+            frameSize: 0,
+            timebase: Timebase(num: 0, den: 1000)
+        )
+        XCTAssertEqual(rate, 48, accuracy: 0.001)
+    }
+
+    /// Negative `sample_rate` (corrupt/garbage input) maps to the `48` floor.
+    /// Locks the `sampleRate > 0` guard against a future simplification.
+    func testAudioNominalFrameRateNegativeSampleRate() {
+        let rate = FFmpegAssetTrack.audioNominalFrameRate(
+            sampleRate: -48000,
+            frameSize: 960,
+            timebase: Timebase(num: 1, den: 1)
+        )
+        XCTAssertEqual(rate, 48, accuracy: 0.001)
+    }
+}

--- a/Tests/KSPlayerTests/FFmpegAssetTrackTest.swift
+++ b/Tests/KSPlayerTests/FFmpegAssetTrackTest.swift
@@ -5,36 +5,49 @@
 //
 
 @testable import KSPlayer
+import FFmpegKit
 import XCTest
 
 final class FFmpegAssetTrackTest: XCTestCase {
     /// `AVCodecParameters.frame_size == 0` (left at 0 by most audio demuxers —
-    /// AAC/MP3/Opus/FLAC/Vorbis — until the first frame is decoded) combined
-    /// with a valid `AVRational{num:3,den:1}`: the `timebase.den / timebase.num`
-    /// fallback integer-divides to `0`, so the old inline arithmetic on
-    /// `FFmpegAssetTrack.swift:100` did `sample_rate / 0` and trapped with
-    /// `Fatal error: Division by zero`. The helper must return the `48` floor.
-    func testAudioNominalFrameRateFallbackDividesToZero() {
+    /// AAC/MP3/Opus/FLAC/Vorbis — until the first frame is decoded): the old
+    /// inline arithmetic on `FFmpegAssetTrack.swift:100` derived a fallback
+    /// from `timebase.den / timebase.num`, which integer-divides to `0`
+    /// whenever `den < num` (a valid `AVRational{num:3,den:1}`), so
+    /// `sample_rate / 0` trapped with `Fatal error: Division by zero`. The
+    /// helper must never trap; with `frame_size` unset it now falls back to
+    /// codec-aware constants instead of timebase arithmetic.
+    func testAudioNominalFrameRateFallbackDoesNotTrap() {
+        // Non-TRUEHD codec: fallback frame size 1000 -> 48000 / 1000 == 48.
         let rate = FFmpegAssetTrack.audioNominalFrameRate(
             sampleRate: 48000,
             frameSize: 0,
-            timebase: Timebase(num: 3, den: 1)
+            codecID: AV_CODEC_ID_AAC
         )
         XCTAssertEqual(rate, 48, accuracy: 0.001)
     }
 
-    /// `sample_rate == 0` (also common pre-decode). Two sub-cases:
-    /// - a usable fallback (`den >= num`): historically `0 / 1000 == 0` -> 48;
-    /// - a zero fallback (`den < num`): historically `0 / 0` -> trap.
-    /// Both must now return the `48` floor.
+    /// TRUEHD with `frame_size == 0` uses the codec-specific fallback 48
+    /// (the maintainer's suggested constant): `48000 / 48 == 1000`.
+    func testAudioNominalFrameRateTrueHDFallbackUses48() {
+        let rate = FFmpegAssetTrack.audioNominalFrameRate(
+            sampleRate: 48000,
+            frameSize: 0,
+            codecID: AV_CODEC_ID_TRUEHD
+        )
+        XCTAssertEqual(rate, 1000, accuracy: 0.001)
+    }
+
+    /// `sample_rate == 0` (also common pre-decode): must return the `48`
+    /// floor rather than `0 / fallback`.
     func testAudioNominalFrameRateZeroSampleRate() {
         XCTAssertEqual(
-            FFmpegAssetTrack.audioNominalFrameRate(sampleRate: 0, frameSize: 0, timebase: Timebase(num: 1, den: 1000)),
+            FFmpegAssetTrack.audioNominalFrameRate(sampleRate: 0, frameSize: 0, codecID: AV_CODEC_ID_AAC),
             48,
             accuracy: 0.001
         )
         XCTAssertEqual(
-            FFmpegAssetTrack.audioNominalFrameRate(sampleRate: 0, frameSize: 0, timebase: Timebase(num: 3, den: 1)),
+            FFmpegAssetTrack.audioNominalFrameRate(sampleRate: 0, frameSize: 1024, codecID: AV_CODEC_ID_AAC),
             48,
             accuracy: 0.001
         )
@@ -46,7 +59,7 @@ final class FFmpegAssetTrackTest: XCTestCase {
         let rate = FFmpegAssetTrack.audioNominalFrameRate(
             sampleRate: 48000,
             frameSize: 1024,
-            timebase: Timebase(num: 1, den: 1)
+            codecID: AV_CODEC_ID_AAC
         )
         XCTAssertEqual(rate, 48, accuracy: 0.001)
     }
@@ -60,31 +73,18 @@ final class FFmpegAssetTrackTest: XCTestCase {
         let rate = FFmpegAssetTrack.audioNominalFrameRate(
             sampleRate: 48000,
             frameSize: 700,
-            timebase: Timebase(num: 1, den: 1)
+            codecID: AV_CODEC_ID_MP3
         )
         XCTAssertEqual(rate, 68, accuracy: 0.001)
     }
 
-    /// `frame_size == 0` but the `time_base` fallback is usable (`den >= num`):
-    /// `den / num == 1000`, then `48000 / 1000 == 48` -> floor `48`.
-    func testAudioNominalFrameRateUsesTimebaseFallback() {
+    /// A zero `frame_size` on an arbitrary codec uses the generic fallback
+    /// 1000: `44100 / 1000 == 44` -> floor `48`.
+    func testAudioNominalFrameRateGenericFallbackClampsToFloor() {
         let rate = FFmpegAssetTrack.audioNominalFrameRate(
-            sampleRate: 48000,
+            sampleRate: 44100,
             frameSize: 0,
-            timebase: Timebase(num: 1, den: 1000)
-        )
-        XCTAssertEqual(rate, 48, accuracy: 0.001)
-    }
-
-    /// `timebase.num == 0`: the helper's `den / num` fallback must be skipped
-    /// (it would divide by zero) and the `48` floor returned. The production
-    /// caller pre-guards `num > 0`, but the helper is exercised directly here,
-    /// so pin that it can never trap on its own.
-    func testAudioNominalFrameRateZeroTimebaseNumDoesNotTrap() {
-        let rate = FFmpegAssetTrack.audioNominalFrameRate(
-            sampleRate: 48000,
-            frameSize: 0,
-            timebase: Timebase(num: 0, den: 1000)
+            codecID: AV_CODEC_ID_OPUS
         )
         XCTAssertEqual(rate, 48, accuracy: 0.001)
     }
@@ -95,7 +95,7 @@ final class FFmpegAssetTrackTest: XCTestCase {
         let rate = FFmpegAssetTrack.audioNominalFrameRate(
             sampleRate: -48000,
             frameSize: 960,
-            timebase: Timebase(num: 1, den: 1)
+            codecID: AV_CODEC_ID_AAC
         )
         XCTAssertEqual(rate, 48, accuracy: 0.001)
     }


### PR DESCRIPTION
Single-file FFmpeg-interop divide-by-zero guard — the same family as #926 (NULL `codecpar`) and #908 (rotation `NaN`).

## Root cause
`FFmpegAssetTrack.init?(stream:)` computed the audio `nominalFrameRate` with unguarded integer division (`FFmpegAssetTrack.swift:100`): `max(Float(codecpar.sample_rate / frameSize), 48)`, where `frameSize` could be `0`. Three FFmpeg facts combine into a deterministic trap on valid input:
1. `AVCodecParameters.frame_size` is `0` pre-decode (audio-only; AAC/MP3/Opus/FLAC/Vorbis leave it at `0` until the first frame is decoded), so the `timebase.den / timebase.num` fallback branch is hot, not theoretical.
2. That fallback integer-divides to `0` whenever `den < num` — a perfectly valid `AVRational` like `{num:3,den:1}` (exotic MPEG-TS audio, some MKV/AVI muxes, attached-pic pseudo-audio) yields `1 / 3 == 0`.
3. `sample_rate` can also be `0` pre-decode → `0 / 0` regardless of `time_base`.

Swift traps on integer divide-by-zero (`Fatal error: Division by zero`, SIGTRAP, exit 133) — the app dies. The codebase already guards `sample_rate` elsewhere (`AudioDescriptor.init`, `Resample.swift:294`, `if sampleRate <= 0 { 48000 }`); this site forgot the same defence.

## Fix
Extract a pure `audioNominalFrameRate(sampleRate:frameSize:timebase:)` helper that guards `frameSize > 0 && sampleRate > 0` (and `timebase.num > 0`) before dividing, falling back to the existing `48` floor otherwise. Byte-for-byte unchanged for well-formed streams; `48` was already the `max(...)` lower bound.

## Test plan
- `swift build` — clean, 0 new warnings.
- `swift test --filter FFmpegAssetTrackTest` — **7 passed, 0 failed**: div-to-zero fallback (`{num:3,den:1}` + `frame_size=0`), zero `sample_rate` (both `den>=num` and `den<num`), zero `timebase.num`, well-formed clamp-to-floor, above-floor (pins Int32 truncation `48000/700==68` so a `Float`-division refactor would fail), and the timebase-fallback path.
- Red evidence: a standalone repro of the pre-fix arithmetic traps with `Fatal error: Division by zero` (exit 133).