### PR TITLE
Fix M3U parser corrupting entries when an EXTINF attribute value is unquoted

### DIFF
--- a/Sources/KSPlayer/Core/Utility.swift
+++ b/Sources/KSPlayer/Core/Utility.swift
@@ -452,6 +452,10 @@ public extension Data {
 }
 
 extension Scanner {
+    /// Characters that terminate an unquoted `#EXTINF` attribute value: the next
+    /// attribute (whitespace separator) or the title comma.
+    private static let unquotedExtInfValueSeparators = CharacterSet(charactersIn: ",").union(.whitespaces)
+
     /*
      #EXTINF:-1 tvg-id="ExampleTV.ua" tvg-logo="https://image.com" group-title="test test", Example TV (720p) [Not 24/7]
      #EXTVLCOPT:http-referrer=http://example.com/
@@ -469,11 +473,21 @@ extension Scanner {
         }
         while scanString(",") == nil {
             let key = scanUpToString("=")
-            _ = scanString("=\"")
-            let value = scanUpToString("\"")
-            _ = scanString("\"")
-            if let key, let value {
-                extinf[key] = value
+            if scanString("=\"") != nil {
+                // Quoted attribute value: read up to the closing quote.
+                let value = scanUpToString("\"")
+                _ = scanString("\"")
+                if let key, let value {
+                    extinf[key] = value
+                }
+            } else {
+                // Unquoted attribute value: a bare scalar terminated by the next
+                // whitespace, the title comma, or the end of the attributes.
+                _ = scanString("=")
+                let value = scanUpToCharacters(from: Scanner.unquotedExtInfValueSeparators)
+                if let key, let value {
+                    extinf[key] = value
+                }
             }
         }
         let title = scanUpToCharacters(from: .newlines)

--- a/Tests/KSPlayerTests/M3UParseTest.swift
+++ b/Tests/KSPlayerTests/M3UParseTest.swift
@@ -15,7 +15,68 @@ class M3UParseTest: XCTestCase {
         if let data {
             let result = data.parsePlaylist()
             XCTAssertEqual(result.count == 2, true)
+            // Tightened: assert a concrete extinf value, not only the entry count.
+            // A dropped/empty attribute dict would still satisfy count == 2.
+            XCTAssertEqual(result.first?.2["tvg-id"], "2365", "first entry extinf: \(result.first?.2 ?? [:])")
         }
+    }
+
+    /// Golden: a fully-quoted EXTINF must keep parsing byte-for-byte. Must never regress.
+    /// Includes a quoted value that itself contains `=` and `,` (a real `catchup-source`
+    /// URL) to prove the quoted branch is never truncated at an inner `=`/`,`.
+    func testParseAllQuotedExtInf() {
+        let data = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id="cctv1" tvg-name="CCTV-1" catchup-source="http://x/?a=1,b=2",CCTV 1
+        http://stream/1
+        """.data(using: .utf8)!
+        let result = data.parsePlaylist()
+        XCTAssertEqual(result.count, 1)
+        let extinf = result.first?.2 ?? [:]
+        XCTAssertEqual(extinf["tvg-id"], "cctv1", "extinf: \(extinf)")
+        XCTAssertEqual(extinf["tvg-name"], "CCTV-1", "extinf: \(extinf)")
+        XCTAssertEqual(extinf["catchup-source"], "http://x/?a=1,b=2", "extinf: \(extinf)")
+        XCTAssertEqual(result.first?.0, "CCTV 1")
+        XCTAssertEqual(result.first?.1.absoluteString, "http://stream/1")
+    }
+
+    /// Red→green core case: an UNQUOTED attribute value. Proves the scanner no longer runs
+    /// past the end of the line / into the next entry to find a closing quote.
+    func testUnquotedExtInfSingleValue() {
+        let data = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id=cctv1 tvg-name="CCTV-1",CCTV 1
+        http://stream/1
+        """.data(using: .utf8)!
+        let result = data.parsePlaylist()
+        XCTAssertEqual(result.count, 1)
+        let extinf = result.first?.2 ?? [:]
+        XCTAssertEqual(extinf["tvg-id"], "cctv1", "extinf: \(extinf)")
+        XCTAssertEqual(extinf["tvg-name"], "CCTV-1", "extinf: \(extinf)")
+        XCTAssertEqual(result.first?.0, "CCTV 1")
+        XCTAssertEqual(result.first?.1.absoluteString, "http://stream/1")
+    }
+
+    /// Entry 1 carries an unquoted attribute; entry 2 is fully quoted. Both must parse with
+    /// no cross-entry bleed — the scanner must not escape entry 1 into entry 2's quotes.
+    func testUnquotedExtInfBleedsAcrossEntries() {
+        let data = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id=chan1 tvg-name="Channel One",Channel One
+        http://stream/1
+        #EXTINF:-1 tvg-id="chan2" tvg-name="Channel Two",Channel Two
+        http://stream/2
+        """.data(using: .utf8)!
+        let result = data.parsePlaylist()
+        XCTAssertEqual(result.count, 2, "got \(result.count) entries: \(result.map { $0.1.absoluteString })")
+        XCTAssertEqual(result[0].2["tvg-id"], "chan1", "entry0 extinf: \(result[0].2)")
+        XCTAssertEqual(result[0].2["tvg-name"], "Channel One", "entry0 extinf: \(result[0].2)")
+        XCTAssertEqual(result[0].0, "Channel One")
+        XCTAssertEqual(result[0].1.absoluteString, "http://stream/1")
+        XCTAssertEqual(result[1].2["tvg-id"], "chan2", "entry1 extinf: \(result[1].2)")
+        XCTAssertEqual(result[1].2["tvg-name"], "Channel Two", "entry1 extinf: \(result[1].2)")
+        XCTAssertEqual(result[1].0, "Channel Two")
+        XCTAssertEqual(result[1].1.absoluteString, "http://stream/2")
     }
 
     func testURLParse() async {


### PR DESCRIPTION
`Scanner.parseM3U()` walked the `#EXTINF` attribute loop assuming every attribute value is double-quoted. Line 472 `_ = scanString("=\"")` requires the literal `="` (equals **plus** opening double-quote); on a non-match `scanString` returns `nil` and consumes nothing, so the next `scanUpToString("\"")` ran forward to the NEXT `"` — often the first quoted attribute of the *following* `#EXTINF` entry. A single unquoted attribute (e.g. `tvg-id=foo` with no surrounding `"`) thus corrupted the current entry AND every following entry until the scanner realigned on a distant quote: titles and stream URLs were swallowed into a garbage blob, entries were silently dropped (`result.count` shrank), and attributes bled across entries.

## Fix
After scanning the key up to `=`, check whether the next characters are `="` (quoted) — if so, read the quoted value up to the closing `"` (current path, byte-for-byte unchanged); if not, read a bare scalar up to the next whitespace or the title comma. The `while scanString(",") == nil` loop still terminates at the title comma for both shapes.

## Test plan
- `swift build` — clean.
- `swift test --filter M3UParseTest` — **5 passed, 0 failed**: a golden all-quoted line (incl. a quoted value that itself contains `=` and `,`, to prove the quoted branch is never truncated at an inner `=`/`,`), an unquoted single-value line, and a two-entry playlist where entry 1 is unquoted and entry 2 is fully quoted — both parse correctly with no cross-entry bleed. The pre-existing `testParsePlaylist` is tightened to assert a concrete `extinf` value (it previously only checked `count == 2`, which passed even if every attribute was dropped).