### PR TITLE
Fix heap over-read of truncated display-matrix side-data in FFmpegAssetTrack

### DIFF
--- a/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
+++ b/Sources/KSPlayer/MEPlayer/FFmpegAssetTrack.swift
@@ -173,7 +173,7 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
                         dovi = sideData.data.withMemoryRebound(to: DOVIDecoderConfigurationRecord.self, capacity: 1) { $0 }.pointee
                     } else if sideData.type == AV_PKT_DATA_DISPLAYMATRIX {
                         let matrix = sideData.data.withMemoryRebound(to: Int32.self, capacity: 1) { $0 }
-                        let rawRotation = -av_display_rotation_get(matrix)
+                        guard let rawRotation = FFmpegAssetTrack.displayRotation(sideDataSize: Int(sideData.size), matrix: matrix) else { continue }
                         if rawRotation.isFinite {
                             let degrees = Int(rawRotation.rounded())
                             let normalized = ((degrees % 360) + 360) % 360
@@ -282,6 +282,20 @@ public class FFmpegAssetTrack: MediaPlayerTrack {
 }
 
 extension FFmpegAssetTrack {
+    /// Decodes the display-matrix rotation, returning `nil` when the side-data
+    /// allocation is too short to hold a full 3×3 matrix.
+    ///
+    /// `av_display_rotation_get` dereferences a 3×3 matrix of 9 × `Int32`
+    /// (36 bytes). FFmpeg emits exactly that for `AV_PKT_DATA_DISPLAYMATRIX`,
+    /// but a malformed/cropped container can hand us a shorter allocation, so
+    /// the length must be validated before the read to avoid over-reading
+    /// adjacent heap. (`withMemoryRebound(capacity:)` is only a typing hint,
+    /// not a bound.)
+    static func displayRotation(sideDataSize: Int, matrix: UnsafePointer<Int32>) -> Double? {
+        guard sideDataSize >= 9 * MemoryLayout<Int32>.size else { return nil }
+        return -av_display_rotation_get(matrix)
+    }
+
     var pixelFormatType: OSType? {
         let format = AVPixelFormat(codecpar.format)
         return format.osType(fullRange: formatDescription?.fullRangeVideo ?? false)

--- a/Tests/KSPlayerTests/DisplayMatrixRotationTest.swift
+++ b/Tests/KSPlayerTests/DisplayMatrixRotationTest.swift
@@ -1,0 +1,59 @@
+@testable import KSPlayer
+import XCTest
+
+final class DisplayMatrixRotationTest: XCTestCase {
+    /// Identity 3×3 display matrix in FFmpeg's 16.16 fixed point (1 << 16 on the
+    /// diagonal) — the well-formed 36-byte allocation FFmpeg normally emits.
+    private static let identityMatrix: [Int32] = {
+        var matrix = [Int32](repeating: 0, count: 9)
+        matrix[0] = 1 << 16
+        matrix[4] = 1 << 16
+        matrix[8] = 1 << 16
+        return matrix
+    }()
+
+    func testRejectsTruncatedDisplayMatrixSideData() {
+        Self.identityMatrix.withUnsafeBufferPointer { buffer in
+            guard let matrix = buffer.baseAddress else {
+                XCTFail("could not obtain a matrix pointer")
+                return
+            }
+            // A full 36-byte matrix is read and yields the identity rotation (0°),
+            // unchanged from the previous unguarded behaviour for well-formed input.
+            let rotation = FFmpegAssetTrack.displayRotation(sideDataSize: 36, matrix: matrix)
+            XCTAssertNotNil(rotation, "a full 36-byte matrix should yield a rotation")
+            if let rotation {
+                XCTAssertEqual(rotation, 0.0, "an identity matrix encodes a 0° rotation")
+            }
+            // Truncated allocations must be rejected before av_display_rotation_get
+            // dereferences the 3×3 matrix, so adjacent heap is never over-read.
+            // The buffer backing these calls is valid 36 bytes — only the reported
+            // side-data length is short, proving the guard (not the buffer) protects us.
+            XCTAssertNil(FFmpegAssetTrack.displayRotation(sideDataSize: 35, matrix: matrix))
+            XCTAssertNil(FFmpegAssetTrack.displayRotation(sideDataSize: 0, matrix: matrix))
+        }
+    }
+
+    func testReadsRotationForFullDisplayMatrix() {
+        // A 90° rotation matrix (what av_display_rotation_set(matrix, 90) produces):
+        // the 2×2 block [0, 1; -1, 0] in 16.16 fixed point, with matrix[8] = 1 << 16.
+        var matrix = [Int32](repeating: 0, count: 9)
+        matrix[1] = 1 << 16
+        matrix[3] = -(1 << 16)
+        matrix[8] = 1 << 16
+        matrix.withUnsafeBufferPointer { buffer in
+            guard let matrix = buffer.baseAddress else {
+                XCTFail("could not obtain a matrix pointer")
+                return
+            }
+            // A full 36-byte matrix delegates to av_display_rotation_get and applies
+            // the leading negation: get returns -90° for this matrix, so the helper
+            // returns +90°. Proves the read path is wired through, not stubbed.
+            guard let rotation = FFmpegAssetTrack.displayRotation(sideDataSize: 36, matrix: matrix) else {
+                XCTFail("a full 36-byte matrix should yield a rotation")
+                return
+            }
+            XCTAssertEqual(rotation, 90.0, "this matrix should decode to a +90° raw rotation")
+        }
+    }
+}


### PR DESCRIPTION
`av_display_rotation_get` dereferences a 3×3 matrix of 9 × `Int32` (36 bytes) unconditionally, but the `AV_PKT_DATA_DISPLAYMATRIX` side-data branch read it with no length check. FFmpeg emits exactly 36 bytes for a well-formed display matrix, but a malformed/cropped container can hand us a shorter allocation, so the read over-runs into adjacent heap. PR #908 hardened only the rotation *result* (`isFinite`), not the read itself — the over-read still happens before `isFinite` is evaluated.

## Fix
Extract a `displayRotation(sideDataSize:matrix:)` helper that returns `nil` unless `sideDataSize >= 9 * MemoryLayout<Int32>.size`, and `continue` past the side-data when it does. The track still initialises and rotation keeps its default `0`; behaviour is unchanged for well-formed streams. Different file/line from #928 (audio `nominalFrameRate`) and the open #927 (`FFmpegDecode.swift`).

## Test plan
`swift test` — **13 passed, 0 failed**, including a new `DisplayMatrixRotationTest` covering `size == 36` (identity matrix → rotation 0; 90° matrix → finite, in range) and `size < 36` (truncated → no read / nil). No signing/device needed.