### PR TITLE
Fix CircularBuffer.search leaking ring slots it skips (crashes subtitle playback after ~255 cues)

### DIFF
--- a/Sources/KSPlayer/MEPlayer/CircularBuffer.swift
+++ b/Sources/KSPlayer/MEPlayer/CircularBuffer.swift
@@ -123,8 +123,23 @@ public class CircularBuffer<Item: ObjectQueueItem> {
             if let item = _buffer[Int(i & mask)] {
                 if predicate(item) {
                     result.append(item)
-                    _buffer[Int(i & mask)] = nil
-                    headIndex = i + 1
+                    // Free every slot the head advances over, not only the match.
+                    //
+                    // Skipped items end up *behind* `headIndex`, so nothing reads
+                    // them again — but leaving them non-nil permanently occupies
+                    // their ring slot. After `initialCapacity` such leaks
+                    // `tailIndex` wraps onto a still-occupied slot and `push`
+                    // trips its "value is not nil" assertion.
+                    //
+                    // Reachable from ordinary playback: `FFmpegAssetTrack.search(for:)`
+                    // matches only the subtitle cues due at the polled instant, so
+                    // every cue stepped over leaks a slot. On a film with embedded
+                    // subtitles the 255-slot queue fills within 10-15 minutes and
+                    // the app traps on KSPlayer_MEPlayerItem_read.
+                    while headIndex <= i {
+                        _buffer[Int(headIndex & mask)] = nil
+                        headIndex &+= 1
+                    }
                 }
             } else {
                 assertionFailure("value is nil of index: \(i) headIndex: \(headIndex), tailIndex: \(tailIndex), bufferCount: \(_buffer.count), mask: \(mask)")


### PR DESCRIPTION
## The bug

`CircularBuffer.search(where:)` nils only the items its predicate matches, then advances `headIndex` past everything it stepped over:

```swift
if predicate(item) {
    result.append(item)
    _buffer[Int(i & mask)] = nil
    headIndex = i + 1          // skipped slots stay non-nil
}
```

Skipped items end up behind `headIndex`, so nothing reads them again — but they are still non-nil and permanently occupy their ring slot. After `initialCapacity` such leaks, `tailIndex` wraps onto a slot that was never freed and `push` trips its assertion.

## Why it is reachable from normal playback

`FFmpegAssetTrack.search(for:)` (EmbedDataSouce.swift) matches only the subtitle cues due at the polled instant, so every cue stepped between polls leaks a slot. The subtitle track is built `frameCapacity: 255, expanding: false`, so on a film with embedded subtitles the ring fills in about 10–15 minutes of dialogue and the app dies on the read thread:

```
CircularBuffer.push(_:)                      <- assertionFailure
closure #1 in SyncPlayerItemTrack.doDecode(packet:)
SubtitleDecode.decodeFrame(from:completionHandler:)
SyncPlayerItemTrack.putPacket(packet:)
MEPlayerItem.reading()
MEPlayerItem.readThread()                    (thread: KSPlayer_MEPlayerItem_read)
```

Reproduced twice on tvOS 26, Apple TV 4K (3rd gen), 2.3.4 — identical stack and fault address both times.

Release builds compile the assertion out and overwrite the stale slot, so the crash is debug-only. The leak is real in both, and once it has happened the ring runs permanently full.

## The fix

Free every slot the head advances over, not only the matched one.

`_count` is derived (`tailIndex &- headIndex`), so advancing the head is already the accounting — no other bookkeeping changes. Uses `&+=` to match the wrapping arithmetic used elsewhere in the type.