### PR TITLE
fix: prevent infinite loop in SrtParse on non-numeric trailing content

### DIFF
--- a/Sources/KSPlayer/Subtitle/KSParseProtocol.swift
+++ b/Sources/KSPlayer/Subtitle/KSParseProtocol.swift
@@ -395,7 +395,11 @@ public class SrtParse: KSParseProtocol {
         repeat {
             decimal = scanner.scanUpToCharacters(from: .newlines)
             _ = scanner.scanCharacters(from: .newlines)
-        } while decimal.flatMap(Int.init) == nil
+            // Stop once the sequence number is found, or once the scanner can no longer
+            // advance. Without the `!scanner.isAtEnd` guard a non-numeric trailing line
+            // (or a truncated cue) makes both scans return nil without advancing, so the
+            // loop would spin forever.
+        } while decimal.flatMap(Int.init) == nil && !scanner.isAtEnd
         let startString = scanner.scanUpToString("-->")
         // skip spaces and newlines by default.
         _ = scanner.scanString("-->")

--- a/Tests/KSPlayerTests/SubtitleTest.swift
+++ b/Tests/KSPlayerTests/SubtitleTest.swift
@@ -58,6 +58,31 @@ class SubtitleTest: XCTestCase {
         XCTAssertEqual(parts[8].end, 3601.14)
     }
 
+    /// An SRT cue whose trailing content is not a numeric sequence line used to put
+    /// `SrtParse.parsePart` into an infinite loop: the sequence-number scan repeats
+    /// `scanUpToCharacters(from: .newlines)` / `scanCharacters(from: .newlines)` and,
+    /// once the scanner reaches a non-numeric line at end of input, neither call
+    /// advances the position nor returns an `Int`, so the loop span forever. The fix
+    /// adds `!scanner.isAtEnd` to the loop guard. This test would hang (never return)
+    /// without it.
+    func testSrtTrailingJunkDoesNotHang() {
+        let string = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        Hello
+
+        SOME JUNK WITHOUT A SEQUENCE NUMBER
+        """
+        let scanner = Scanner(string: string)
+        let parse = SrtParse()
+        XCTAssertTrue(parse.canParse(scanner: scanner))
+        // Must terminate: the lone valid cue is parsed, the trailing junk is skipped.
+        let parts = parse.parse(scanner: scanner)
+        XCTAssertEqual(parts.count, 1)
+        XCTAssertEqual(parts[0].start, 1.0)
+        XCTAssertEqual(parts[0].end, 2.0)
+    }
+
     func testVtt() {
         let string = """
         WEBVTT


### PR DESCRIPTION
## Problem

`SrtParse.parsePart` can hang forever (infinite loop) while parsing SRT input whose trailing content is not a numeric cue index. Reproduces with any of:

- a stray non-numeric line after the last cue (e.g. a truncated download, a BOM/separator line, a tool signature);
- trailing whitespace-only lines;
- an SRT-shaped file that contains ` --> ` (so `canParse` accepts it) but never yields a numeric sequence line.

Once this happens the whole subtitle parser never returns.

## Root cause

The sequence-number scan in `SrtParse.parsePart` has no end-of-input guard:

```swift
repeat {
    decimal = scanner.scanUpToCharacters(from: .newlines)
    _ = scanner.scanCharacters(from: .newlines)
} while decimal.flatMap(Int.init) == nil
```

When the scanner is parked on a non-numeric line at end of input, `scanUpToCharacters(from: .newlines)` returns `nil` (the current character is already a newline / EOF) and `scanCharacters(from: .newlines)` returns `nil` (nothing left to consume). Neither call advances the position, and `decimal.flatMap(Int.init)` stays `nil`, so the loop spins forever.

The sibling VTT parser already defends against this — `VTTParse.parsePart` terminates its timestamp-scan loop with `&& !scanner.isAtEnd`; SRT was simply missing the same guard.

## Fix

Add `&& !scanner.isAtEnd` to the loop condition (one line). After the loop, `scanner.scanUpToString("-->")` returns `nil` at EOF, the existing `if let startString, let endString = …` check fails, `parsePart` returns `nil`, and the outer `while !scanner.isAtEnd` loop in `parse(scanner:)` exits cleanly.

## Verification

- `swift build` for macOS: clean.
- `swift test --filter SubtitleTest`: passes (3 cases), including the new `testSrtTrailingJunkDoesNotHang` and the existing `testSrt` (still 9 cues, `parts[8].end == 3601.14` — no regression).
- Without the guard the new test never returns (the loop hangs), which is exactly the bug.
