### PR TITLE
fix: prevent infinite loop in AssParse.canParse on header without Format line

### DIFF
--- a/Sources/KSPlayer/Subtitle/KSParseProtocol.swift
+++ b/Sources/KSPlayer/Subtitle/KSParseProtocol.swift
@@ -53,6 +53,13 @@ public class AssParse: KSParseProtocol {
             } else {
                 _ = scanner.scanUpToCharacters(from: .newlines)
             }
+            // A [Script Info] block with no `Format:` line (truncated/malformed header,
+            // or a file whose Styles section was stripped). At EOF neither the
+            // `scanString("Format:")` test above nor the line skip advances the scanner,
+            // so without this guard the loop would spin forever.
+            if scanner.isAtEnd {
+                return false
+            }
         }
         guard var keys = scanner.scanUpToCharacters(from: .newlines)?.components(separatedBy: ",") else {
             return false

--- a/Tests/KSPlayerTests/SubtitleTest.swift
+++ b/Tests/KSPlayerTests/SubtitleTest.swift
@@ -99,4 +99,34 @@ class SubtitleTest: XCTestCase {
         let parts = parse.parse(scanner: scanner)
         XCTAssertEqual(parts.count, 7)
     }
+
+    /// An ASS file whose `[Script Info]` section has no `Format:` line (a truncated
+    /// header, or one whose `[V4+ Styles]` section was stripped) used to put
+    /// `AssParse.canParse` into an infinite loop. The `while scanString("Format:") == nil`
+    /// line-skip calls `scanUpToCharacters(from: .newlines)`, which returns `nil`
+    /// without advancing once the scanner reaches EOF, so the loop span forever. The
+    /// fix bails out with `return false` when the scanner is at end. Without the fix
+    /// this test would hang (never return).
+    func testAssWithoutFormatLineDoesNotHang() {
+        let malformed = """
+        [Script Info]
+        ScriptType: v4.00+
+        PlayResX: 1920
+        PlayResY: 1080
+        Title: header only, styles section missing
+        """
+        XCTAssertFalse(AssParse().canParse(scanner: Scanner(string: malformed)))
+
+        // Happy path is unaffected: a header that does contain a `Format:` line still parses.
+        let valid = """
+        [Script Info]
+        ScriptType: v4.00+
+        PlayResX: 1920
+        PlayResY: 1080
+
+        [V4+ Styles]
+        Format: Name, Fontname, Fontsize, PrimaryColour
+        """
+        XCTAssertTrue(AssParse().canParse(scanner: Scanner(string: valid)))
+    }
 }


### PR DESCRIPTION
## Problem

`AssParse.canParse` hangs forever (infinite loop) on an ASS file whose `[Script Info]` section contains no `Format:` line. This is reachable from real inputs:

- a truncated / partially-downloaded `.ass` file;
- an ASS file whose `[V4+ Styles]` section was stripped or renamed;
- any file beginning with `[Script Info]` (so the initial guard passes) but missing the styles format header.

Because `AssParse` is the first parser tried in `KSOptions.subtitleParses`, `canParse` runs on every subtitle load, so any such file hangs the whole subtitle pipeline instead of falling through to the VTT/SRT parsers.

## Root cause

```swift
while scanner.scanString("Format:") == nil {
    if scanner.scanString("PlayResX:") != nil { ... }
    else if scanner.scanString("PlayResY:") != nil { ... }
    else { _ = scanner.scanUpToCharacters(from: .newlines) }
}
```

The line-skip uses `scanUpToCharacters(from: .newlines)`, which reads up to the next newline but does not consume it. Mid-file this is harmless because the scanner's default `charactersToBeSkipped` (whitespace + newlines) lets the next `scanString("Format:")` skip past the newline. But once the scanner is at EOF, `scanUpToCharacters(from: .newlines)` returns `nil` without advancing, `scanString("Format:")` returns `nil` without advancing, and the loop spins forever.

## Fix

Add an end-of-input guard inside the loop:

```swift
if scanner.isAtEnd {
    return false
}
```

A header with no `Format:` line is not a valid ASS file for this parser, so returning `false` is correct — `KSOptions.subtitleParses.first { $0.canParse(...) }` then tries `VTTParse` / `SrtParse` as intended.

## Verification

- `swift build` for macOS: clean.
- `swift test --filter SubtitleTest`: passes (3 cases), including the new `testAssWithoutFormatLineDoesNotHang`. The test asserts a malformed header (no `Format:`) returns `false` and a valid header still returns `true`; without the guard the malformed assertion never returns (the loop hangs).
